### PR TITLE
Storm Drain: import shapefile, save .INP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pylint.log
 *.gpkg-journal
 *flo2d.zip
 *.bak
+.project
+.pydevproject

--- a/flo2d/gui/dlg_conduits.py
+++ b/flo2d/gui/dlg_conduits.py
@@ -304,10 +304,10 @@ class ConduitsDialog(qtBaseClass, uiDialog):
                             self.to_node_txt.setText(str(data))
 
                         elif element == 4:
-                            self.inlet_offset_dbox.setValue(data)
+                            self.inlet_offset_dbox.setValue(data if data is not None else 0)
 
                         elif element == 5:
-                            self.outlet_offset_dbox.setValue(data)
+                            self.outlet_offset_dbox.setValue(data if data is not None else 0)
 
                         elif element == 6:
                             if data.isdigit():
@@ -318,40 +318,40 @@ class ConduitsDialog(qtBaseClass, uiDialog):
                                 self.conduit_shape_cbo.setCurrentIndex(index)
 
                         elif element == 7:
-                            self.barrels_sbox.setValue(data)
+                            self.barrels_sbox.setValue(data if data is not None else 0)
 
                         elif element == 8:
-                            self.max_depth_dbox.setValue(data)
+                            self.max_depth_dbox.setValue(data if data is not None else 0)
 
                         elif element == 9:
-                            self.geom2_dbox.setValue(data)
+                            self.geom2_dbox.setValue(data if data is not None else 0)
 
                         elif element == 10:
-                            self.geom3_dbox.setValue(data)
+                            self.geom3_dbox.setValue(data if data is not None else 0)
 
                         elif element == 11:
-                            self.geom4_dbox.setValue(data)
+                            self.geom4_dbox.setValue(data if data is not None else 0)
 
                         elif element == 12:
-                            self.length_dbox.setValue(data)
+                            self.length_dbox.setValue(data if data is not None else 0)
 
                         elif element == 13:
-                            self.mannings_dbox.setValue(data)
+                            self.mannings_dbox.setValue(data if data is not None else 0)
 
                         elif element == 14:
-                            self.initial_flow_dbox.setValue(data)
+                            self.initial_flow_dbox.setValue(data if data is not None else 0)
 
                         elif element == 15:
-                            self.max_flow_dbox.setValue(data)
+                            self.max_flow_dbox.setValue(data if data is not None else 0)
 
                         elif element == 16:
-                            self.inlet_losses_dbox.setValue(data)
+                            self.inlet_losses_dbox.setValue(data if data is not None else 0)
 
                         elif element == 17:
-                            self.outlet_losses_dbox.setValue(data)
+                            self.outlet_losses_dbox.setValue(data if data is not None else 0)
 
                         elif element == 18:
-                            self.average_losses_dbox.setValue(data)
+                            self.average_losses_dbox.setValue(data if data is not None else 0)
 
                         elif element == 19:
                             self.flap_gate_chbox.setChecked(1 if is_true(data) else 0)

--- a/flo2d/gui/dlg_inlets.py
+++ b/flo2d/gui/dlg_inlets.py
@@ -249,33 +249,33 @@ class InletNodesDialog(qtBaseClass, uiDialog):
                     if cell == 1:
                         self.grid_element.setText(str(data))
                     elif cell == 2:
-                        self.invert_elevation_dbox.setValue(data)
+                        self.invert_elevation_dbox.setValue(data if data is not None else 0)
                     elif cell == 3:
-                        self.max_depth_dbox.setValue(data)
+                        self.max_depth_dbox.setValue(data if data is not None else 0)
                     elif cell == 4:
-                        self.initial_depth_dbox.setValue(data)
+                        self.initial_depth_dbox.setValue(data if data is not None else 0)
                     elif cell == 5:
-                        self.surcharge_depth_dbox.setValue(data)
+                        self.surcharge_depth_dbox.setValue(data if data is not None else 0)
                     elif cell == 6:
-                        self.ponded_area_dbox.setValue(data)
+                        self.ponded_area_dbox.setValue(data if data is not None else 0)
                     elif cell == 7:
                         self.inlet_drain_type_cbo.setCurrentIndex(data-1)
                     elif cell == 8:
-                        self.length_dbox.setValue(data)
+                        self.length_dbox.setValue(data if data is not None else 0)
                     elif cell == 9:
-                        self.width_dbox.setValue(data)
+                        self.width_dbox.setValue(data if data is not None else 0)
                     elif cell == 10:
-                        self.height_dbox.setValue(data)
+                        self.height_dbox.setValue(data if data is not None else 0)
                     elif cell == 11:
-                        self.weir_coeff_dbox.setValue(data)
+                        self.weir_coeff_dbox.setValue(data if data is not None else 0)
                     elif cell == 12:
-                        self.feature_sbox.setValue(data)
+                        self.feature_sbox.setValue(data if data is not None else 0)
                     elif cell == 13:
-                        self.curb_height_dbox.setValue(data)
+                        self.curb_height_dbox.setValue(data if data is not None else 0)
                     elif cell == 14:
-                        self.clogging_factor_dbox.setValue(data)
+                        self.clogging_factor_dbox.setValue(data if data is not None else 0)
                     elif cell == 15:
-                        self.time_for_clogging_dbox.setValue(data)
+                        self.time_for_clogging_dbox.setValue(data if data is not None else 0)
 
                 if cell == 1 or cell == 2:
                         item.setFlags( Qt.ItemIsSelectable | Qt.ItemIsEnabled )

--- a/flo2d/gui/dlg_outfalls.py
+++ b/flo2d/gui/dlg_outfalls.py
@@ -94,13 +94,14 @@ class OutfallNodesDialog(qtBaseClass, uiDialog):
                             time_series              
                     FROM user_swmm_nodes WHERE sd_type = 'O';'''
 
-            rows = self.gutils.execute(qry).fetchall()  # rows is a list of tuples
+            rows = self.gutils.execute(qry).fetchall()  # rows is a list of tuples.
             self.outfalls_tblw.setRowCount(0)
             for row_number, row_data in enumerate(rows):       # In each iteration gets a tuble, for example:  0, ('fid'12, 'name''OUT3', 2581, 'False', 'False' 0,0,0, '', '')
                 self.outfalls_tblw.insertRow(row_number)
                 for col_number, data in enumerate(row_data):   # For each iteration gets, for example: first iteration:  0, 12. 2nd. iteration 1, 'OUT3', etc
+
                     item = QTableWidgetItem()
-                    item.setData(Qt.DisplayRole, data)  # item gets value of data (as QTableWidgetItem Class)
+                    item.setData(Qt.DisplayRole, data if data is not None else 0)  # item gets value of data (as QTableWidgetItem Class)
 
                     # Fill the list of outfall names:
                     if col_number == 1:   #We need 2nd. col_number: 'OUT3' in the example above, and its fid from row_data[0]
@@ -111,7 +112,7 @@ class OutfallNodesDialog(qtBaseClass, uiDialog):
                         if col_number == 2:
                             self.grid_element_txt.setText(str(data))
                         elif col_number == 3:
-                            self.invert_elevation_dbox.setValue(data)
+                            self.invert_elevation_dbox.setValue(data if data is not None else 0)
                         elif col_number == 4:
                             self.flap_gate_chbox.setChecked(1 if is_true(data) else 0)
                         elif col_number == 5:
@@ -125,7 +126,7 @@ class OutfallNodesDialog(qtBaseClass, uiDialog):
                             data = self.outfall_type_cbo.currentText()
                             item.setData(Qt.DisplayRole, data)
                         elif col_number == 7:
-                            self.water_depth_dbox.setValue(data)
+                            self.water_depth_dbox.setValue(data if data is not None else 0)
                         elif col_number == 8:
                             self.tidal_curve_cbo.setCurrentIndex(0)
                         elif col_number == 9:

--- a/flo2d/gui/dlg_stormdrain_shapefile.py
+++ b/flo2d/gui/dlg_stormdrain_shapefile.py
@@ -7,9 +7,9 @@
 # as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version
 
-from qgis.PyQt.QtWidgets import QDialogButtonBox
+from qgis.PyQt.QtWidgets import QDialogButtonBox 
 from qgis.core import QgsFeature, QgsGeometry, QgsWkbTypes
-
+from qgis.gui import QgsFieldComboBox
 from qgis.PyQt.QtWidgets import QApplication, QComboBox
 
 from .ui_utils import load_ui
@@ -42,38 +42,61 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
         self.outfalls_shapefile_cbo.currentIndexChanged.connect(self.populate_outfalls_attributes)
         self.conduits_shapefile_cbo.currentIndexChanged.connect(self.populate_conduits_attributes)
 
-        self.clear_invert_elev_btn.clicked.connect(self.clear_invert_elev)
+        # Connections to clear inlets fields.
+        self.clear_inlets_name_btn.clicked.connect(self.clear_inlets_name)
+        self.clear_inlets_invert_elev_btn.clicked.connect(self.clear_inlets_invert_elevation)
+        self.clear_inlets_max_depth_btn.clicked.connect(self.clear_inlets_max_depth)        
+        self.clear_inlets_init_depth_btn.clicked.connect(self.clear_inlets_init_depth)              
+        self.clear_inlets_surcharge_depth_btn.clicked.connect(self.clear_inlets_surcharge_dept) 
+        self.clear_inlets_ponded_area_btn.clicked.connect(self.clear_inlets_ponded_area)   
+        self.clear_inlets_length_perimeter_btn.clicked.connect(self.clear_inlets_length_perimeter)    
+        self.clear_inlets_width_area_btn.clicked.connect(self.clear_inlets_width_area)    
+        self.clear_inlets_height_sag_surch_btn.clicked.connect(self.clear_inlets_height_sag_surch)
+        self.clear_inlets_weir_coeff_btn.clicked.connect(self.clear_inlets_weir_coeff)           
+        self.clear_inlets_feature_btn.clicked.connect(self.clear_inlets_feature)           
+        self.clear_inlets_curb_height_btn.clicked.connect(self.clear_inlets_curb_height)           
+        self.clear_inlets_clogging_factor_btn.clicked.connect(self.clear_inlets_clogging_factor)
+        self.clear_inlets_time_for_clogging_btn.clicked.connect(self.clear_inlets_time_for_clogging)                
+        
+        # Connections to clear outfalls fields.
+        self.clear_outfall_name_btn.clicked.connect(self.clear_outfall_name)
+        self.clear_outfall_invert_elevation_btn.clicked.connect(self.clear_outfall_invert_elevation)
+        self.clear_outfall_flap_gate_btn.clicked.connect(self.clear_outfall_flap_gate)
+        self.clear_outfall_allow_discharge_btn.clicked.connect(self.clear_outfall_allow_discharge)
+        self.clear_outfall_type_btn.clicked.connect(self.clear_outfall_type)
+        self.clear_outfall_water_depth_btn.clicked.connect(self.clear_outfall_water_depth)
+        self.clear_outfall_tidal_curve_btn.clicked.connect(self.clear_outfall_tidal_curve)
+        self.clear_outfall_time_series_btn.clicked.connect(self.clear_outfall_time_series)                        
+
+        # Connections to clear conduits fields.
+        self.clear_conduit_name_btn.clicked.connect(self.clear_conduit_name)        
+        self.clear_conduit_from_inlet_btn.clicked.connect(self.clear_conduit_from_inlet)        
+        self.clear_conduit_to_outlet_btn.clicked.connect(self.clear_conduit_to_outlet)        
+        self.clear_conduit_inlet_offset_btn.clicked.connect(self.clear_conduit_inlet_offset)        
+        self.clear_conduit_outlet_offset_btn.clicked.connect(self.clear_conduit_outlet_offset)        
+        self.clear_conduit_shape_btn.clicked.connect(self.clear_conduit_shape)        
+        self.clear_conduit_barrels_btn.clicked.connect(self.clear_conduit_barrels)        
+        self.clear_conduit_max_depth_btn.clicked.connect(self.clear_conduit_max_depth)        
+        self.clear_conduit_geom2_btn.clicked.connect(self.clear_conduit_geom2)        
+        self.clear_conduit_geom3_btn.clicked.connect(self.clear_conduit_geom3)        
+        self.clear_conduit_geom4_btn.clicked.connect(self.clear_conduit_geom4)        
+        self.clear_conduit_length_btn.clicked.connect(self.clear_conduit_length)        
+        self.clear_conduit_manning_btn.clicked.connect(self.clear_conduit_manning)        
+        self.clear_conduit_initial_flow_btn.clicked.connect(self.clear_conduit_initial_flow)        
+        self.clear_conduit_max_flow_btn.clicked.connect(self.clear_conduit_max_flow)        
+        self.clear_conduit_entry_loss_btn.clicked.connect(self.clear_conduit_entry_loss)        
+        self.clear_conduit_exit_loss_btn.clicked.connect(self.clear_conduit_exit_loss)        
+        self.clear_conduit_average_loss_btn.clicked.connect(self.clear_conduit_average_loss)        
+        self.clear_conduit_flap_gate_btn.clicked.connect(self.clear_conduit_flap_gate)        
+        
+        
+        
         self.clear_all_inlets_btn.clicked.connect(self.clear_all_inlets_attributes)
         self.clear_all_outfalls_btn.clicked.connect(self.clear_all_outfalls_attributes)
         self.clear_all_conduits_btn.clicked.connect(self.clear_all_conduits_attributes)
         self.SDSF_buttonBox.accepted.connect(self.assign_components_from_shapefile)
         self.SDSF_buttonBox.rejected.connect(self.cancel_message)
-        # self.clear_max_depth_btn.clicked.connect(self.clear_)
-        # self.clear_init_depth_btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
-        # self.clear__btn.clicked.connect(self.clear_)
 
-    # def __init__(self, con, iface, lyrs):
-    #     qtBaseClass.__init__(self)
-    #     uiDialog.__init__(self)
-    #     self.con = con
-    #     self.iface = iface
-    #     self.lyrs = lyrs
-    #     self.setupUi(self)
-    #     self.gutils = GeoPackageUtils(con, iface)
-    #     self.gpkg_path = self.gutils.get_gpkg_path()
-    #     self.uc = UserCommunication(iface, 'FLO-2D')
-    #     self.current_lyr = None
-    #     self.setup_layer_cbo()
-    #     # connections
-    #     self.points_cbo.currentIndexChanged.connect(self.populate_fields_cbo)
 
     def setup_layers_comboxes(self):
         try:
@@ -132,8 +155,131 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
         nFeatures = self.current_lyr.featureCount()
         self.conduits_fields_groupBox.setTitle("Conduits Fields Selection (from '" + self.conduits_shapefile_cbo.currentText() + "' layer with " + str(nFeatures) + " features (lines))")
 
-    def clear_invert_elev(self):
-        self.inlets_invert_elevation_FieldCbo.setCurrentIndex(-1)
+#     def clear_invert_elev(self):
+#         self.inlets_invert_elevation_FieldCbo.setCurrentIndex(-1)
+
+    # CLEAR INLETS FIELDS:
+    def clear_inlets_name(self):
+        self.inlets_name_FieldCbo.setCurrentIndex(-1)
+    def clear_inlets_invert_elevation(self):
+           self.inlets_invert_elevation_FieldCbo.setCurrentIndex(-1) 
+    def clear_inlets_max_depth(self):
+           self.inlets_max_depth_FieldCbo.setCurrentIndex(-1)      
+    def clear_inlets_init_depth(self):
+            self.inlets_init_depth_FieldCbo.setCurrentIndex(-1)                                  
+    def clear_inlets_surcharge_dept(self):
+            self.inlets_surcharge_depth_FieldCbo.setCurrentIndex(-1)                   
+    def clear_inlets_weir_coeff(self):            
+            self.inlets_weir_coeff_FieldCbo.setCurrentIndex(-1)             
+    def clear_inlets_feature(self):           
+            self.inlets_feature_FieldCbo.setCurrentIndex(-1)             
+    def clear_inlets_curb_height(self):         
+            self.inlets_curb_height_FieldCbo.setCurrentIndex(-1)             
+    def clear_inlets_clogging_factor(self):              
+            self.inlets_clogging_factor_FieldCbo.setCurrentIndex(-1)             
+    def clear_inlets_time_for_clogging(self):              
+             self.inlets_time_for_clogging_FieldCbo.setCurrentIndex(-1)             
+    def clear_inlets_ponded_area(self):              
+            self.inlets_ponded_area_FieldCbo.setCurrentIndex(-1)             
+    def clear_inlets_length_perimeter(self):          
+            self.inlets_length_perimeter_FieldCbo.setCurrentIndex(-1)             
+    def clear_inlets_width_area(self):          
+            self.inlets_width_area_FieldCbo.setCurrentIndex(-1)           
+    def clear_inlets_height_sag_surch(self):              
+            self.inlets_height_sag_surch_FieldCbo.setCurrentIndex(-1)   
+
+    # CLEAR OUTFALLS FIELDS:
+    def clear_outfall_name(self):
+        self.outfall_name_FieldCbo.setCurrentIndex(-1)
+    def clear_outfall_invert_elevation(self):
+        self.outfall_invert_elevation_FieldCbo.setCurrentIndex(-1)
+    def clear_outfall_flap_gate(self):
+        self.outfall_flap_gate_FieldCbo.setCurrentIndex(-1)
+    def clear_outfall_allow_discharge(self):
+        self.outfall_allow_discharge_FieldCbo.setCurrentIndex(-1)
+    def clear_outfall_type(self):
+        self.outfall_type_FieldCbo.setCurrentIndex(-1)
+    def clear_outfall_water_depth(self):
+        self.outfall_water_depth_FieldCbo.setCurrentIndex(-1)
+    def clear_outfall_tidal_curve(self):
+        self.outfall_tidal_curve_FieldCbo.setCurrentIndex(-1)
+    def clear_outfall_time_series(self):
+        self.outfall_time_series_FieldCbo.setCurrentIndex(-1)
+
+        # CLEAR CONDUITS FIELDS:
+    def clear_conduit_name(self):
+        self.conduit_name_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_from_inlet(self):
+        self.conduit_from_inlet_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_to_outlet(self):
+        self.conduit_to_outlet_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_inlet_offset(self):
+        self.conduit_inlet_offset_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_outlet_offset(self):
+        self.conduit_outlet_offset_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_shape(self):
+        self.conduit_shape_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_barrels(self):
+        self.conduit_barrels_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_max_depth(self):
+        self.conduit_max_depth_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_geom2(self):
+        self.conduit_geom2_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_geom3(self):
+        self.conduit_geom3_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_geom4(self):
+        self.conduit_geom4_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_length(self):
+        self.conduit_length_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_manning(self):
+        self.conduit_manning_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_initial_flow(self):
+        self.conduit_initial_flow_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_max_flow(self):
+        self.conduit_max_flow_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_entry_loss(self):
+        self.conduit_entry_loss_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_exit_loss(self):
+        self.conduit_exit_loss_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_average_loss(self):
+        self.conduit_average_loss_FieldCbo.setCurrentIndex(-1)
+    def clear_conduit_flap_gate(self):
+        self.conduit_flap_gate_FieldCbo.setCurrentIndex(-1)
+
+
+
+
+
+#     def clear_field(self, fld):
+#         if fld == "inlets_name":
+#              self.inlets_name_FieldCbo.setCurrentIndex(-1)
+#         elif fld == "inlets_invert_elevation":  
+#            self.inlets_invert_elevation_FieldCbo.setCurrentIndex(-1) 
+#         elif fld == "inlets_max_depth":  
+#            self.inlets_max_depth_FieldCbo.setCurrentIndex(-1)      
+#         elif fld == "inlets_init_depth":  
+#             self.inlets_init_depth_FieldCbo.setCurrentIndex(-1)                                  
+#         elif fld == "inlets_surcharge_depth":  
+#             self.inlets_surcharge_depth_FieldCbo.setCurrentIndex(-1)                   
+#         elif fld == "inlets_weir_coeff":              
+#             self.inlets_weir_coeff_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_feature":             
+#             self.inlets_feature_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_curb_height":              
+#             self.inlets_curb_height_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_clogging_factor":              
+#             self.inlets_clogging_factor_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_time_for_clogging":              
+#              self.inlets_time_for_clogging_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_ponded_area":              
+#             self.inlets_ponded_area_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_length_perimeter":              
+#             self.inlets_length_perimeter_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_width_area":              
+#             self.inlets_width_area_FieldCbo.setCurrentIndex(-1)             
+#         elif fld == "inlets_height_sag_surch":              
+#             self.inlets_height_sag_surch_FieldCbo.setCurrentIndex(-1)               
+
 
     def clear_all_inlets_attributes(self):
         self.inlets_name_FieldCbo.setCurrentIndex(-1)
@@ -156,31 +302,31 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
         self.outfall_invert_elevation_FieldCbo.setCurrentIndex(-1)
         self.outfall_flap_gate_FieldCbo.setCurrentIndex(-1)
         self.outfall_allow_discharge_FieldCbo.setCurrentIndex(-1)
-        self.outfall_outfall_type_FieldCbo.setCurrentIndex(-1)
+        self.outfall_type_FieldCbo.setCurrentIndex(-1)
         self.outfall_water_depth_FieldCbo.setCurrentIndex(-1)
         self.outfall_tidal_curve_FieldCbo.setCurrentIndex(-1)
         self.outfall_time_series_FieldCbo.setCurrentIndex(-1)
 
     def clear_all_conduits_attributes(self):
-        self.conduits_name_FieldCbo.setCurrentIndex(-1)
-        self.conduits_from_inlet_FieldCbo.setCurrentIndex(-1)
-        self.conduits_to_outlet_FieldCbo.setCurrentIndex(-1)
-        self.conduits_inlet_offset_FieldCbo.setCurrentIndex(-1)
-        self.conduits_outlet_offset_FieldCbo.setCurrentIndex(-1)
-        self.conduits_shape_FieldCbo.setCurrentIndex(-1)
-        self.conduits_barrels_FieldCbo.setCurrentIndex(-1)
-        self.conduits_max_depth_FieldCbo.setCurrentIndex(-1)
-        self.conduits_geom2_FieldCbo.setCurrentIndex(-1)
-        self.conduits_geom3_FieldCbo.setCurrentIndex(-1)
-        self.conduits_geom4_FieldCbo.setCurrentIndex(-1)
-        self.conduits_length_FieldCbo.setCurrentIndex(-1)
-        self.conduits_manning_FieldCbo.setCurrentIndex(-1)
-        self.conduits_initial_flow_FieldCbo.setCurrentIndex(-1)
-        self.conduits_max_flow_FieldCbo.setCurrentIndex(-1)
-        self.conduits_inlet_losses_FieldCbo.setCurrentIndex(-1)
-        self.conduits_outlet_losses_FieldCbo.setCurrentIndex(-1)
-        self.conduits_average_losses_FieldCbo.setCurrentIndex(-1)
-        self.conduits_flap_gate_FieldCbo.setCurrentIndex(-1)
+        self.conduit_name_FieldCbo.setCurrentIndex(-1)
+        self.conduit_from_inlet_FieldCbo.setCurrentIndex(-1)
+        self.conduit_to_outlet_FieldCbo.setCurrentIndex(-1)
+        self.conduit_inlet_offset_FieldCbo.setCurrentIndex(-1)
+        self.conduit_outlet_offset_FieldCbo.setCurrentIndex(-1)
+        self.conduit_shape_FieldCbo.setCurrentIndex(-1)
+        self.conduit_barrels_FieldCbo.setCurrentIndex(-1)
+        self.conduit_max_depth_FieldCbo.setCurrentIndex(-1)
+        self.conduit_geom2_FieldCbo.setCurrentIndex(-1)
+        self.conduit_geom3_FieldCbo.setCurrentIndex(-1)
+        self.conduit_geom4_FieldCbo.setCurrentIndex(-1)
+        self.conduit_length_FieldCbo.setCurrentIndex(-1)
+        self.conduit_manning_FieldCbo.setCurrentIndex(-1)
+        self.conduit_initial_flow_FieldCbo.setCurrentIndex(-1)
+        self.conduit_max_flow_FieldCbo.setCurrentIndex(-1)
+        self.conduit_entry_loss_FieldCbo.setCurrentIndex(-1)
+        self.conduit_exit_loss_FieldCbo.setCurrentIndex(-1)
+        self.conduit_average_loss_FieldCbo.setCurrentIndex(-1)
+        self.conduit_flap_gate_FieldCbo.setCurrentIndex(-1)
 
     def assign_components_from_shapefile(self):
         # self.saveSelected = True
@@ -251,9 +397,11 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
 
                     fields = self.user_swmm_nodes_lyr.fields()
                     new_feats = []
-
+                    
                     inlets_shapefile = self.inlets_shapefile_cbo.currentText()
-                    lyr = self.lyrs.get_layer_by_name(inlets_shapefile, group=self.lyrs.group).layer()
+                    group =  self.lyrs.group
+                    lyr = self.lyrs.get_layer_by_name(inlets_shapefile, group).layer() 
+                            
                     inlets_shapefile_fts = lyr.getFeatures()
 
                     for f in inlets_shapefile_fts:
@@ -282,16 +430,24 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                         if geom is None:
                             QApplication.restoreOverrideCursor()
                             self.uc.show_warn("Error processing geometry of inlet/junction '" + name + "' !")
+                            continue
 
                         point = geom.asPoint()
                         if point is None:
                             QApplication.restoreOverrideCursor()
-                            self.uc.show_warn("Point of inlet/junction '" + name + "' outside domain!")
-
+                            self.uc.show_warn("Inlet/junction  " + name + "  is faulty!")
+                            continue
+                        
+                        cell = self.gutils.grid_on_point(point.x(), point.y())
+                        if cell is None:
+                            QApplication.restoreOverrideCursor()
+                            self.uc.show_warn("Inlet/junction  " + name + "  is outside the computational domain!")
+                            continue    
+                                            
                         new_geom = QgsGeometry.fromPointXY(point)
                         feat.setGeometry(new_geom)
 
-                        feat.setAttribute('grid', 0)
+                        feat.setAttribute('grid', cell)
                         feat.setAttribute('sd_type', 'I')
                         feat.setAttribute('name', name)
                         feat.setAttribute('intype', 1)
@@ -340,7 +496,8 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
 
                 except Exception as e:
                     QApplication.restoreOverrideCursor()
-                    self.uc.show_error("ERROR 070618.0451: creation of Storm Drain Modes (Inlets) layer failed!", e)
+                    self.uc.show_error("ERROR 070618.0451: creation of Storm Drain Modes (Inlets) layer failed!"
+                               +'\n__________________________________________________', e)
 
             # Load outfalls from shapefile:
             if load_outfalls:
@@ -350,7 +507,7 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                     new_feats = []
 
                     outfalls_shapefile = self.outfalls_shapefile_cbo.currentText()
-                    lyr = self.lyrs.get_layer_by_name(outfalls_shapefile, group=self.lyrs.group).layer()
+                    lyr = self.lyrs.get_layer_by_name(outfalls_shapefile, self.lyrs.group).layer()
                     outfalls_shapefile_fts = lyr.getFeatures()
 
                     for f in outfalls_shapefile_fts:
@@ -374,16 +531,24 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                         if geom is None:
                             QApplication.restoreOverrideCursor()
                             self.uc.show_warn("Error processing geometry of outfall'" + name + "' !")
-                            return
+                            continue
+                        
                         point = geom.asPoint()
                         if point is None:
                             QApplication.restoreOverrideCursor()
-                            self.uc.show_warn("Point of outfall'" + name + "' outside domain!")
-                            return
+                            self.uc.show_warn("Outfall  " + name + "  is faulty!")
+                            continue
+                        
+                        cell = self.gutils.grid_on_point(point.x(), point.y())
+                        if cell is None:
+                            QApplication.restoreOverrideCursor()
+                            self.uc.show_warn("Outfall  " + name + "  is outside the computationsl domain!")
+                            continue                        
+                        
                         new_geom = QgsGeometry.fromPointXY(point)
                         feat.setGeometry(new_geom)
 
-                        feat.setAttribute('grid', 0)
+                        feat.setAttribute('grid', cell)
                         feat.setAttribute('sd_type', 'O')
                         feat.setAttribute('name', name)
                         feat.setAttribute('intype', 1)
@@ -440,30 +605,31 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                     new_feats = []
 
                     conduits_shapefile = self.conduits_shapefile_cbo.currentText()
-                    lyr = self.lyrs.get_layer_by_name(conduits_shapefile, group=self.lyrs.group).layer()
+                    lyr = self.lyrs.get_layer_by_name(conduits_shapefile, self.lyrs.group).layer()
                     conduits_shapefile_fts = lyr.getFeatures()
-
+                    no_in_out = 0
+                    
                     for f in conduits_shapefile_fts:
 
-                        conduit_name = f[self.conduits_name_FieldCbo.currentText()] if self.conduits_name_FieldCbo.currentText() != "" else ""
-                        conduit_inlet = f[self.conduits_from_inlet_FieldCbo.currentText()] if self.conduits_from_inlet_FieldCbo.currentText() != "" else ""
-                        conduit_outlet = f[self.conduits_to_outlet_FieldCbo.currentText()] if self.conduits_to_outlet_FieldCbo.currentText() != "" else ""
-                        conduit_inlet_offset = f[self.conduits_inlet_offset_FieldCbo.currentText()] if self.conduits_inlet_offset_FieldCbo.currentText() != "" else 0
-                        conduit_outlet_offset = f[self.conduits_outlet_offset_FieldCbo.currentText()] if self.conduits_outlet_offset_FieldCbo.currentText() != "" else 0
-                        conduit_shape = f[self.conduits_shape_FieldCbo.currentText()] if self.conduits_shape_FieldCbo.currentText() != "" else 0
-                        conduit_max_depth = f[self.conduits_max_depth_FieldCbo.currentText()] if self.conduits_max_depth_FieldCbo.currentText() != "" else 0
-                        conduit_geom2 = f[self.conduits_geom2_FieldCbo.currentText()] if self.conduits_geom2_FieldCbo.currentText() != "" else 0
-                        conduit_geom3 = f[self.conduits_geom3_FieldCbo.currentText()] if self.conduits_geom3_FieldCbo.currentText() != "" else 0
-                        conduit_geom4 = f[self.conduits_geom4_FieldCbo.currentText()] if self.conduits_geom4_FieldCbo.currentText() != "" else 0
-                        conduit_barrels = f[self.conduits_barrels_FieldCbo.currentText()] if self.conduits_barrels_FieldCbo.currentText() != "" else 0
-                        conduit_length  = f[self.conduits_length_FieldCbo.currentText()] if self.conduits_length_FieldCbo.currentText() != "" else 0
-                        conduit_manning  = f[self.conduits_manning_FieldCbo.currentText()] if self.conduits_manning_FieldCbo.currentText() != "" else 0
-                        conduit_init_flow = f[self.conduits_initial_flow_FieldCbo.currentText()] if self.conduits_initial_flow_FieldCbo.currentText() != "" else 0
-                        conduit_max_flow = f[self.conduits_max_flow_FieldCbo.currentText()] if self.conduits_max_flow_FieldCbo.currentText() != "" else 0
-                        conduit_losses_inlet = f[self.conduits_inlet_losses_FieldCbo.currentText()] if self.conduits_inlet_losses_FieldCbo.currentText() != "" else 0
-                        conduit_losses_outlet = f[self.conduits_outlet_losses_FieldCbo.currentText()] if self.conduits_outlet_losses_FieldCbo.currentText() != "" else 0
-                        conduit_losses_average = f[self.conduits_average_losses_FieldCbo.currentText()] if self.conduits_average_losses_FieldCbo.currentText() != "" else 0
-                        conduits_flap_gate = f[self.conduits_flap_gate_FieldCbo.currentText()] if self.conduits_flap_gate_FieldCbo.currentText() != "" else 0
+                        conduit_name = f[self.conduit_name_FieldCbo.currentText()] if self.conduit_name_FieldCbo.currentText() != "" else ""
+                        conduit_inlet = f[self.conduit_from_inlet_FieldCbo.currentText()] if self.conduit_from_inlet_FieldCbo.currentText() != "" else "?"
+                        conduit_outlet = f[self.conduit_to_outlet_FieldCbo.currentText()] if self.conduit_to_outlet_FieldCbo.currentText() != "" else "?"
+                        conduit_inlet_offset = f[self.conduit_inlet_offset_FieldCbo.currentText()] if self.conduit_inlet_offset_FieldCbo.currentText() != "" else 0
+                        conduit_outlet_offset = f[self.conduit_outlet_offset_FieldCbo.currentText()] if self.conduit_outlet_offset_FieldCbo.currentText() != "" else 0
+                        conduit_shape = f[self.conduit_shape_FieldCbo.currentText()] if self.conduit_shape_FieldCbo.currentText() != "" else 0
+                        conduit_max_depth = f[self.conduit_max_depth_FieldCbo.currentText()] if self.conduit_max_depth_FieldCbo.currentText() != "" else 0
+                        conduit_geom2 = f[self.conduit_geom2_FieldCbo.currentText()] if self.conduit_geom2_FieldCbo.currentText() != "" else 0
+                        conduit_geom3 = f[self.conduit_geom3_FieldCbo.currentText()] if self.conduit_geom3_FieldCbo.currentText() != "" else 0
+                        conduit_geom4 = f[self.conduit_geom4_FieldCbo.currentText()] if self.conduit_geom4_FieldCbo.currentText() != "" else 0
+                        conduit_barrels = f[self.conduit_barrels_FieldCbo.currentText()] if self.conduit_barrels_FieldCbo.currentText() != "" else 0
+                        conduit_length  = f[self.conduit_length_FieldCbo.currentText()] if self.conduit_length_FieldCbo.currentText() != "" else 0
+                        conduit_manning  = f[self.conduit_manning_FieldCbo.currentText()] if self.conduit_manning_FieldCbo.currentText() != "" else 0
+                        conduit_init_flow = f[self.conduit_initial_flow_FieldCbo.currentText()] if self.conduit_initial_flow_FieldCbo.currentText() != "" else 0
+                        conduit_max_flow = f[self.conduit_max_flow_FieldCbo.currentText()] if self.conduit_max_flow_FieldCbo.currentText() != "" else 0
+                        conduit_entry_loss = f[self.conduit_entry_loss_FieldCbo.currentText()] if self.conduit_entry_loss_FieldCbo.currentText() != "" else 0
+                        conduit_exit_loss = f[self.conduit_exit_loss_FieldCbo.currentText()] if self.conduit_exit_loss_FieldCbo.currentText() != "" else 0
+                        conduit_loss_average = f[self.conduit_average_loss_FieldCbo.currentText()] if self.conduit_average_loss_FieldCbo.currentText() != "" else 0
+                        conduits_flap_gate = f[self.conduit_flap_gate_FieldCbo.currentText()] if self.conduit_flap_gate_FieldCbo.currentText() != "" else 0
 
                         # xsections_shape  = f[self.conduits_manning_FieldCbo.currentText()] if self.conduits_manning_FieldCbo.currentText() != "" else 0
                         # xsections_barrels = f[self.conduits_initial_flow_FieldCbo.currentText()] if self.conduits_initial_flow_FieldCbo.currentText() != "" else 0
@@ -472,6 +638,9 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                         # xsections_geom2 = f[self.conduits_outlet_losses_FieldCbo.currentText()] if self.conduits_outlet_losses_FieldCbo.currentText() != "" else 0
                         # xsections_geom2 = f[self.conduits_average_losses_FieldCbo.currentText()] if self.conduits_average_losses_FieldCbo.currentText() != "" else 0
 
+                        if conduit_inlet == "?" or conduit_outlet == "?":
+                            no_in_out += 1
+                            
                         feat = QgsFeature()
                         feat.setFields(fields)
 
@@ -479,8 +648,14 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                         if geom is None:
                             QApplication.restoreOverrideCursor()
                             self.uc.show_warn("Error processing geometry of conduit '" + conduit_name +"' !")
-                            return
+                            continue
+                        
                         line = geom.asPolyline()
+                        if line is None:
+                            QApplication.restoreOverrideCursor()
+                            self.uc.show_warn("Conduit " + name + " is faulty!")
+                            continue
+                                                
                         new_geom = QgsGeometry.fromPolylineXY(line)
                         feat.setGeometry(new_geom)
 
@@ -493,9 +668,9 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                         feat.setAttribute('conduit_manning', conduit_manning)
                         feat.setAttribute('conduit_init_flow', conduit_init_flow)
                         feat.setAttribute('conduit_max_flow', conduit_max_flow)
-                        feat.setAttribute('losses_inlet', conduit_losses_inlet)
-                        feat.setAttribute('losses_outlet', conduit_losses_outlet)
-                        feat.setAttribute('losses_average', conduit_losses_average)
+                        feat.setAttribute('losses_inlet', conduit_entry_loss)
+                        feat.setAttribute('losses_outlet', conduit_exit_loss)
+                        feat.setAttribute('losses_average', conduit_loss_average)
                         feat.setAttribute('losses_flapgate', conduits_flap_gate)
                         feat.setAttribute('xsections_shape', 'CIRCULAR')
                         feat.setAttribute('xsections_barrels', conduit_barrels)
@@ -517,14 +692,30 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
                     self.user_swmm_conduits_lyr.removeSelection()
 
                     QApplication.restoreOverrideCursor()
-                    self.uc.show_info("Importing SWMM input data finished!\n\n" +
-                                      "The 'Storm Drain Nodes' and 'Storm Drain Conduits' layers were created in the 'User Layers' group.\n\n"
-                                      "Use the 'Inlets', 'Outlets', and 'Conduits' buttons in the Storm Drain Editor widget to see/edit their attributes.\n\n"
-                                      "NOTE: the 'Schematize Storm Drain Components' button will update the 'Storm Drain' layer group.")
 
+                    if no_in_out != 0:
+                        self.uc.show_warn(str(no_in_out) + " conduits have no inlet and/or outlet!\n" +
+                                                           "The value '?' was assigned to them. It will cause errors during their processing.\n" +
+                                                           "Did you select the 'From Inlet' and 'To Oulet' fields in the shapefile?" )                     
+                        
                 except Exception as e:
                     QApplication.restoreOverrideCursor()
                     self.uc.show_error("ERROR 070618.0500: creation of Storm Drain Modes (Conduits) layer failed!", e)
 
+            if (load_inlets or load_outfalls) and load_conduits:
+                self.uc.show_info("Importing SWMM input data finished!\n\n" +
+                                  "The 'Storm Drain Nodes' and 'Storm Drain Conduits' layers were created in the 'User Layers' group.\n\n"
+                                  "Use the 'Inlets', 'Outlets', and 'Conduits' buttons in the Storm Drain Editor widget to see/edit their attributes.\n\n"
+                                  "NOTE: the 'Schematize Storm Drain Components' button will update the 'Storm Drain' layer group.")
+            elif not (load_inlets or load_outfalls) and load_conduits:
+                self.uc.show_info("Importing SWMM input data finished!\n\n" +
+                                  "The 'Storm Drain Conduits' layer was created in the 'User Layers' group.\n\n"
+                                  "Use the 'Inlets', 'Outlets', and 'Conduits' buttons in the Storm Drain Editor widget to see/edit their attributes.\n\n"
+                                  "NOTE: the 'Schematize Storm Drain Components' button will update the 'Storm Drain' layer group.")   
+            elif (load_inlets or load_outfalls) and not load_conduits:
+                self.uc.show_info("Importing SWMM input data finished!\n\n" +
+                                  "The 'Storm Drain Nodes' layer was created in the 'User Layers' group.\n\n"
+                                  "Use the 'Inlets', 'Outlets', and 'Conduits' buttons in the Storm Drain Editor widget to see/edit their attributes.\n\n"
+                                  "NOTE: the 'Schematize Storm Drain Components' button will update the 'Storm Drain' layer group.")
     def cancel_message(self):
         self.uc.show_warn("No data was selected!")

--- a/flo2d/ui/inp_groups.ui
+++ b/flo2d/ui/inp_groups.ui
@@ -1,0 +1,722 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>INP_groups_dlg</class>
+ <widget class="QDialog" name="INP_groups_dlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>521</width>
+    <height>583</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Export Storm Drain .INP file</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <widget class="QGroupBox" name="optionsGroup">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>120</y>
+     <width>301</width>
+     <height>441</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="title">
+    <string>[ OPTIONS ]</string>
+   </property>
+   <property name="flat">
+    <bool>false</bool>
+   </property>
+   <widget class="QSplitter" name="splitter">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>126</width>
+      <height>401</height>
+     </rect>
+    </property>
+    <property name="orientation">
+     <enum>Qt::Vertical</enum>
+    </property>
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>FLOW_UNITS</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_7">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>FLOW_ROUTING</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>START_DATE</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>START_TIME</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>REPORT_START_DATE</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>REPORT_START_TIME</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>END_DATE</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_12">
+     <property name="text">
+      <string>END_TIME</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>REPORT_STEP</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_21">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>INERTIAL_DAMPING</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_22">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>NORMAL_FLOW_LIM ITED</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_26">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>SKIP_STEADY_STATE</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_23">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>FORCE_MAIN_EQUATION</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_24">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>LINK_OFFSETS</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_25">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>MIN_SLOPE</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </widget>
+   <widget class="QSplitter" name="splitter_2">
+    <property name="geometry">
+     <rect>
+      <x>151</x>
+      <y>20</y>
+      <width>136</width>
+      <height>401</height>
+     </rect>
+    </property>
+    <property name="orientation">
+     <enum>Qt::Vertical</enum>
+    </property>
+    <widget class="QComboBox" name="flow_units_cbo">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>CFS</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>CMS</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QComboBox" name="flow_routing_cbo">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>DYNWAVE</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QDateEdit" name="start_date">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+    <widget class="QTimeEdit" name="start_time">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+    <widget class="QDateEdit" name="report_start_date">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+    <widget class="QTimeEdit" name="report_start_time">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+    <widget class="QDateEdit" name="end_date">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+    <widget class="QTimeEdit" name="end_time">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+    <widget class="QTimeEdit" name="report_stp_time">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="inertial_damping_cbo">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>PARTIAL</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>KEEP</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>DAMPING</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>IGNORE</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QComboBox" name="normal_flow_limited_cbo">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>BOTH</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>SLOPE</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>FROUDE</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QComboBox" name="skip_steady_state_cbo">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>NO</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>YES</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QComboBox" name="force_main_equation_cbo">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>Hazen-William (H-M)</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Darcy-Weisbach (D-W)</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QComboBox" name="link_offsets_cbo">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>DEPTH</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>ELEVATION</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QDoubleSpinBox" name="min_slop_dbox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimum">
+      <double>0.010000000000000</double>
+     </property>
+    </widget>
+   </widget>
+  </widget>
+  <widget class="QDialogButtonBox" name="components_buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>340</x>
+     <y>540</y>
+     <width>156</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QGroupBox" name="reportGroup">
+   <property name="geometry">
+    <rect>
+     <x>340</x>
+     <y>120</y>
+     <width>134</width>
+     <height>131</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="title">
+    <string>[ REPORT ]</string>
+   </property>
+   <property name="flat">
+    <bool>false</bool>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_5">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>INPUT</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QComboBox" name="input_cbo">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <item>
+       <property name="text">
+        <string>YES</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>NO</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_13">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>CONTROLS</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QComboBox" name="controls_cbo">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <item>
+       <property name="text">
+        <string>YES</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>NO</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_19">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>NODES</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QComboBox" name="nodes_cbo">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <item>
+       <property name="text">
+        <string>ALL</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>NONE</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_15">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>LINKS</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QComboBox" name="links_cbo">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <item>
+       <property name="text">
+        <string>ALL</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>NONE</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QGroupBox" name="titleGroup">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>20</y>
+     <width>491</width>
+     <height>91</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>[ TITLE ]</string>
+   </property>
+   <widget class="QTextEdit" name="titleTextEdit">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>461</width>
+      <height>61</height>
+     </rect>
+    </property>
+    <property name="html">
+     <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;INP file created by FLO-2D&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+  </widget>
+ </widget>
+ <layoutdefault spacing="6" margin="9"/>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>components_buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>INP_groups_dlg</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>381</x>
+     <y>549</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>385</x>
+     <y>571</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>components_buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>INP_groups_dlg</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>445</x>
+     <y>549</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>458</x>
+     <y>586</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <designerdata>
+  <property name="gridDeltaX">
+   <number>10</number>
+  </property>
+  <property name="gridDeltaY">
+   <number>10</number>
+  </property>
+  <property name="gridSnapX">
+   <bool>true</bool>
+  </property>
+  <property name="gridSnapY">
+   <bool>true</bool>
+  </property>
+  <property name="gridVisible">
+   <bool>true</bool>
+  </property>
+ </designerdata>
+ <slots>
+  <signal>signal1()</signal>
+  <slot>slot1()</slot>
+ </slots>
+</ui>

--- a/flo2d/ui/stormdrain_shapefile.ui
+++ b/flo2d/ui/stormdrain_shapefile.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>736</width>
+    <width>747</width>
     <height>544</height>
    </rect>
   </property>
@@ -29,7 +29,7 @@
     <cursorShape>ArrowCursor</cursorShape>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>2</number>
    </property>
    <widget class="QWidget" name="inlets_tab">
     <attribute name="title">
@@ -75,7 +75,7 @@
       <rect>
        <x>16</x>
        <y>72</y>
-       <width>665</width>
+       <width>673</width>
        <height>281</height>
       </rect>
      </property>
@@ -111,481 +111,547 @@
        <bool>false</bool>
       </property>
      </widget>
-     <widget class="QWidget" name="layoutWidget">
+     <widget class="QWidget" name="">
       <property name="geometry">
        <rect>
-        <x>24</x>
-        <y>24</y>
-        <width>305</width>
+        <x>11</x>
+        <y>33</y>
+        <width>96</width>
+        <height>193</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_11">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_22">
+         <property name="text">
+          <string>Inlet Name</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Invert Elevation</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Max. Depth</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Init. Depth</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Surcharge Depth</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>Ponded Area</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_11">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Length/Perimeter *</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>114</x>
+        <y>32</y>
+        <width>177</width>
         <height>201</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_name_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="inputMethodHints">
+          <set>Qt::ImhNone</set>
+         </property>
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_invert_elevation_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="inputMethodHints">
+          <set>Qt::ImhNone</set>
+         </property>
+         <property name="editable">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_max_depth_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_init_depth_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_surcharge_depth_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_ponded_area_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_length_perimeter_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>296</x>
+        <y>32</y>
+        <width>25</width>
+        <height>201</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_6">
+       <item row="0" column="0">
+        <widget class="QPushButton" name="clear_inlets_name_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="clear_inlets_invert_elev_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="clear_inlets_max_depth_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="clear_inlets_init_depth_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QPushButton" name="clear_inlets_surcharge_depth_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QPushButton" name="clear_inlets_ponded_area_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QPushButton" name="clear_inlets_length_perimeter_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>344</x>
+        <y>32</y>
+        <width>97</width>
+        <height>193</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_15">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Width/Area *</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Height/Sag/Surch *</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Weir Coeff. *</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_12">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Feature *</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Curb Height *</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_15">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Clogging Factor #</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_16">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Time for Clogging #</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>448</x>
+        <y>32</y>
+        <width>177</width>
+        <height>200</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_12">
        <item row="0" column="0">
-        <layout class="QGridLayout" name="gridLayout_11">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_22">
-           <property name="text">
-            <string>Inlet Name</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Invert Elevation</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Max. Depth</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Init. Depth</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_8">
-           <property name="text">
-            <string>Surcharge Depth</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label_9">
-           <property name="text">
-            <string>Ponded Area</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_11">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Length/Perimeter *</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QgsFieldComboBox" name="inlets_width_area_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
        </item>
-       <item row="0" column="1">
-        <layout class="QGridLayout" name="gridLayout_6">
-         <item row="0" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_name_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="inputMethodHints">
-            <set>Qt::ImhNone</set>
-           </property>
-           <property name="editable">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_invert_elevation_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="inputMethodHints">
-            <set>Qt::ImhNone</set>
-           </property>
-           <property name="editable">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_max_depth_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_init_depth_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_surcharge_depth_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_ponded_area_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_length_perimeter_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_height_sag_surch_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
        </item>
-       <item row="0" column="2">
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="0">
-          <widget class="QPushButton" name="clear_inlets_name_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="clear_invert_elev_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QPushButton" name="clear_max_depth_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QPushButton" name="clear_init_depth_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QPushButton" name="clear_surcharge_depth_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QPushButton" name="clear_ponded_area_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QPushButton" name="clear__length_perim_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="2" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_weir_coeff_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_feature_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_curb_height_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_clogging_factor_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QgsFieldComboBox" name="inlets_time_for_clogging_FieldCbo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="layoutWidget">
+     <widget class="QWidget" name="">
       <property name="geometry">
        <rect>
-        <x>352</x>
-        <y>24</y>
-        <width>289</width>
+        <x>632</x>
+        <y>32</y>
+        <width>25</width>
         <height>201</height>
        </rect>
       </property>
-      <layout class="QGridLayout" name="gridLayout_16">
+      <layout class="QGridLayout" name="gridLayout_13">
        <item row="0" column="0">
-        <layout class="QGridLayout" name="gridLayout_15">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_10">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Width/Area *</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_7">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Height/Sag/Surch *</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_13">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Weir Coeff. *</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_12">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Feature *</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_14">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Curb Height *</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label_15">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Clogging Factor #</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_16">
-           <property name="font">
-            <font>
-             <italic>true</italic>
-            </font>
-           </property>
-           <property name="text">
-            <string>Time for Clogging #</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QPushButton" name="clear_inlets_width_area_btn">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
        </item>
-       <item row="0" column="1">
-        <layout class="QGridLayout" name="gridLayout_14">
-         <item row="0" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_width_area_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_height_sag_surch_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_weir_coeff_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_feature_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_curb_height_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_clogging_factor_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QgsFieldComboBox" name="inlets_time_for_clogging_FieldCbo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="clear_inlets_height_sag_surch_btn">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
        </item>
-       <item row="0" column="2">
-        <layout class="QGridLayout" name="gridLayout_13">
-         <item row="0" column="0">
-          <widget class="QPushButton" name="clear_width_area_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="clear_height_sag_surch_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QPushButton" name="clear_weir_coeff_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QPushButton" name="clear_feature_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QPushButton" name="clear_curb_height_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QPushButton" name="clear_clogging_factor_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QPushButton" name="clear_time_for_clogging_btn">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="clear_inlets_weir_coeff_btn">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="clear_inlets_feature_btn">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QPushButton" name="clear_inlets_curb_height_btn">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QPushButton" name="clear_inlets_clogging_factor_btn">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QPushButton" name="clear_inlets_time_for_clogging_btn">
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -726,10 +792,10 @@
        <string>Unselect All Outfall Fields</string>
       </property>
      </widget>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <property name="geometry">
        <rect>
-        <x>152</x>
+        <x>130</x>
         <y>24</y>
         <width>353</width>
         <height>206</height>
@@ -979,7 +1045,7 @@
           </widget>
          </item>
          <item row="4" column="0">
-          <widget class="QgsFieldComboBox" name="outfall_outfall_type_FieldCbo">
+          <widget class="QgsFieldComboBox" name="outfall_type_FieldCbo">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -1019,6 +1085,122 @@
           </widget>
          </item>
         </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>490</x>
+        <y>26</y>
+        <width>25</width>
+        <height>201</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_14">
+       <item row="0" column="0">
+        <widget class="QPushButton" name="clear_outfall_name_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="clear_outfall_invert_elevation_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="clear_outfall_flap_gate_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="clear_outfall_allow_discharge_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QPushButton" name="clear_outfall_type_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QPushButton" name="clear_outfall_water_depth_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QPushButton" name="clear_outfall_tidal_curve_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QPushButton" name="clear_outfall_time_series_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -1110,7 +1292,7 @@
       <rect>
        <x>16</x>
        <y>80</y>
-       <width>657</width>
+       <width>673</width>
        <height>361</height>
       </rect>
      </property>
@@ -1133,9 +1315,9 @@
      <widget class="QGroupBox" name="geometry_groupBox">
       <property name="geometry">
        <rect>
-        <x>16</x>
+        <x>8</x>
         <y>160</y>
-        <width>289</width>
+        <width>313</width>
         <height>185</height>
        </rect>
       </property>
@@ -1249,7 +1431,7 @@
         <item row="0" column="1">
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="0" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_shape_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_shape_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1259,7 +1441,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_barrels_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_barrels_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1269,7 +1451,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_max_depth_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_max_depth_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1279,7 +1461,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_geom2_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_geom2_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1289,7 +1471,7 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_geom3_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_geom3_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1299,7 +1481,7 @@
            </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_geom4_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_geom4_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1312,13 +1494,103 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="layoutWidget_5">
+       <property name="geometry">
+        <rect>
+         <x>278</x>
+         <y>16</y>
+         <width>25</width>
+         <height>153</height>
+        </rect>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_26">
+        <item row="3" column="0">
+         <widget class="QPushButton" name="clear_conduit_geom2_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QPushButton" name="clear_conduit_shape_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QPushButton" name="clear_conduit_barrels_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QPushButton" name="clear_conduit_geom3_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QPushButton" name="clear_conduit_max_depth_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QPushButton" name="clear_conduit_geom4_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
      <widget class="QGroupBox" name="physical_properties_groupBox">
       <property name="geometry">
        <rect>
-        <x>312</x>
+        <x>336</x>
         <y>16</y>
-        <width>313</width>
+        <width>329</width>
         <height>137</height>
        </rect>
       </property>
@@ -1382,7 +1654,7 @@
         <item row="0" column="1">
          <layout class="QGridLayout" name="gridLayout_9">
           <item row="0" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_length_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_length_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1392,7 +1664,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_manning_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_manning_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1402,7 +1674,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_initial_flow_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_initial_flow_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1412,7 +1684,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_max_flow_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_max_flow_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1425,13 +1697,77 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="layoutWidget_3">
+       <property name="geometry">
+        <rect>
+         <x>293</x>
+         <y>18</y>
+         <width>24</width>
+         <height>105</height>
+        </rect>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_24">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="clear_conduit_length_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QPushButton" name="clear_conduit_max_flow_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QPushButton" name="clear_conduit_manning_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QPushButton" name="clear_conduit_initial_flow_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
      <widget class="QGroupBox" name="conduit_losses_groupBox">
       <property name="geometry">
        <rect>
-        <x>312</x>
+        <x>336</x>
         <y>160</y>
-        <width>313</width>
+        <width>329</width>
         <height>129</height>
        </rect>
       </property>
@@ -1495,7 +1831,7 @@
         <item row="0" column="1">
          <layout class="QGridLayout" name="gridLayout_19">
           <item row="2" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_average_losses_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_average_loss_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1505,7 +1841,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_outlet_losses_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_exit_loss_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1515,7 +1851,7 @@
            </widget>
           </item>
           <item row="0" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_inlet_losses_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_entry_loss_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1525,7 +1861,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QgsFieldComboBox" name="conduits_flap_gate_FieldCbo">
+           <widget class="QgsFieldComboBox" name="conduit_flap_gate_FieldCbo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1538,11 +1874,75 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="layoutWidget_4">
+       <property name="geometry">
+        <rect>
+         <x>300</x>
+         <y>15</y>
+         <width>25</width>
+         <height>104</height>
+        </rect>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_25">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="clear_conduit_entry_loss_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QPushButton" name="clear_conduit_flap_gate_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QPushButton" name="clear_conduit_exit_loss_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QPushButton" name="clear_conduit_average_loss_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>x</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
      <widget class="QWidget" name="layoutWidget">
       <property name="geometry">
        <rect>
-        <x>24</x>
+        <x>18</x>
         <y>24</y>
         <width>265</width>
         <height>128</height>
@@ -1606,7 +2006,7 @@
        <item row="0" column="1">
         <layout class="QGridLayout" name="gridLayout_22">
          <item row="0" column="0">
-          <widget class="QgsFieldComboBox" name="conduits_name_FieldCbo">
+          <widget class="QgsFieldComboBox" name="conduit_name_FieldCbo">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -1616,7 +2016,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QgsFieldComboBox" name="conduits_from_inlet_FieldCbo">
+          <widget class="QgsFieldComboBox" name="conduit_from_inlet_FieldCbo">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -1626,7 +2026,7 @@
           </widget>
          </item>
          <item row="2" column="0">
-          <widget class="QgsFieldComboBox" name="conduits_to_outlet_FieldCbo">
+          <widget class="QgsFieldComboBox" name="conduit_to_outlet_FieldCbo">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -1636,7 +2036,7 @@
           </widget>
          </item>
          <item row="3" column="0">
-          <widget class="QgsFieldComboBox" name="conduits_inlet_offset_FieldCbo">
+          <widget class="QgsFieldComboBox" name="conduit_inlet_offset_FieldCbo">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -1646,7 +2046,7 @@
           </widget>
          </item>
          <item row="4" column="0">
-          <widget class="QgsFieldComboBox" name="conduits_outlet_offset_FieldCbo">
+          <widget class="QgsFieldComboBox" name="conduit_outlet_offset_FieldCbo">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -1656,6 +2056,83 @@
           </widget>
          </item>
         </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="layoutWidget_2">
+      <property name="geometry">
+       <rect>
+        <x>288</x>
+        <y>24</y>
+        <width>25</width>
+        <height>129</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_16">
+       <item row="0" column="0">
+        <widget class="QPushButton" name="clear_conduit_name_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="clear_conduit_from_inlet_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="clear_conduit_to_outlet_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QPushButton" name="clear_conduit_outlet_offset_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="clear_conduit_inlet_offset_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Storm Drain Editor widget: 
-New dialog to select fields from shapefiles for Inlet/Junctions, Outfalls, and Conduits components.
-Extensive checkings of data entered in the 'Components' dialogs.
-New 'Import SWMM.inp' and Éxport SWMM.inp' functionality
