### PR TITLE
Write ARF.DAT with 2 decimal points only

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -528,6 +528,12 @@ class Flo2D(object):
                 self.gutils = dlg_settings.gutils
                 self.crs = dlg_settings.crs
                 self.setup_dock_widgets()
+                
+                s = QSettings()
+                s.setValue('FLO-2D/last_flopro_project', old_gpkg)
+                s.setValue('FLO-2D/lastGdsDir', old_gpkg)
+                window_title = s.value('FLO-2D/last_flopro_project', '')
+                self.iface.mainWindow().setWindowTitle(window_title)                             
             else:
                 self.uc.bar_info('Loading last model cancelled', dur=3)
                 return

--- a/flo2d/flo2d_ie/flo2dgeopackage.py
+++ b/flo2d/flo2d_ie/flo2dgeopackage.py
@@ -1298,8 +1298,8 @@ class Flo2dGeoPackage(GeoPackageUtils):
 
         line1 = 'S  {}\n'
         line2 = ' T   {}\n'
-        line3 = '   {}' * 10 + '\n'
-
+#         line3 = '   {}' * 10 + '\n'
+        line3 = '{0:<8} {1:<7.2f} {2:<7.2f} {3:<7.2f} {4:<7.2f} {5:<7.2f} {6:<7.2f} {7:<7.2f} {8:<7.2f} {9:<7.2f}\n'
         option = self.execute(cont_sql).fetchone()
         if option is None:
             # TODO: We need to implement correct export of 'arfblockmod'

--- a/flo2d/gui/xs_editor_widget.py
+++ b/flo2d/gui/xs_editor_widget.py
@@ -173,6 +173,7 @@ class XsecEditorWidget(qtBaseClass, uiDialog):
             res, msg = seg.interpolate_bed()
             if not res:
                 self.uc.log_info(msg)
+                self.uc.show_warn(msg)
                 return False
         return True
 


### PR DESCRIPTION
ARF.DAT is written with only 2 decimal points in WRF lines:

404      0.41    0.21    1.00    0.37    0.00    1.00    1.00    0.00    0.00   
405      0.48    0.37    1.00    0.52    0.00    1.00    1.00    0.00    0.00   
406      0.01    0.52    0.00    0.00    0.00    0.05    0.00    0.00    0.00   
442      0.21    0.00    0.42    0.31    0.00    0.00    1.00    0.00    0.00   