### PR TITLE
Create grid tool assigns n-manning from 'cont' table

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -538,16 +538,6 @@ class Flo2D(object):
                 self.uc.bar_info('Loading last model cancelled', dur=3)
                 return
 
-        # old_gpkg = self.read_proj_entry('gpkg')
-        # if old_gpkg:
-        #     dlg_settings = SettingsDialog(self.con, self.iface, self.lyrs, self.gutils)
-        #     dlg_settings.connect(old_gpkg)
-        #     self.con = dlg_settings.con
-        #     self.iface.f2d['con'] = self.con
-        #     self.gutils = dlg_settings.gutils
-        #     self.crs = dlg_settings.crs
-        #     self.setup_dock_widgets()
-
     def call_methods(self, calls, debug, *args):
         self.files_imported = ""
         n_found = 0
@@ -614,7 +604,8 @@ class Flo2D(object):
         fname, __ = QFileDialog.getOpenFileName(None, 'Select FLO-2D file to import', directory=last_dir, filter='CONT.DAT')
         if not fname:
             return
-        s.setValue('FLO-2D/lastGdsDir', os.path.dirname(fname))
+        dir_name = os.path.dirname(fname)
+        s.setValue('FLO-2D/lastGdsDir', dir_name)
         bname = os.path.basename(fname)
         if self.f2g.set_parser(fname):
             topo = self.f2g.parser.dat_files['TOPO.DAT']

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -126,6 +126,11 @@ class GridToolsWidget(qtBaseClass, uiDialog):
             QApplication.setOverrideCursor(Qt.WaitCursor)
             bl = self.lyrs.data['user_model_boundary']['qlyr']
             square_grid(self.gutils, bl)
+            
+            default = self.gutils.get_cont_par('MANNING')
+            self.gutils.execute('UPDATE grid SET n_value=?;', (default,))            
+            
+            
             grid_lyr = self.lyrs.data['grid']['qlyr']
             self.lyrs.update_layer_extents(grid_lyr)
             if grid_lyr:


### PR DESCRIPTION
Grid Tool "Create Grid" in Grid Tools widget creates a grid (layer "Grid" in Schematic Layers) with n-value attribute taken from Control table (MANNING field in "cont" layer), which in turn was assigned during initial Settings (settings dialog) as Default Manning's n:
![image](https://user-images.githubusercontent.com/20424575/48809541-6168ba80-ecfb-11e8-85a8-dc61470f9cca.png)


