### PR TITLE
Levee elevations tool enforces use of levee lines

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -1130,25 +1130,13 @@ class Flo2D(object):
         while True:
             ok = dlg_levee_elev.exec_()
             if ok:
-                if dlg_levee_elev.methods:
-                    break
-#                 else:
-#                     self.uc.show_warn('Please choose at least one crest elevation source!')    
+                if dlg_levee_elev.methods: 
+                    if 1 in dlg_levee_elev.methods:
+                        break 
+                    else:
+                        self.uc.show_info('Levee user lines required!')
             else:
-                return
-
-
-
-
-#         ok = dlg_levee_elev.exec_()
-#         if ok:
-#             if dlg_levee_elev.methods:
-#                 pass
-#             else:
-#                 self.uc.show_warn('Please choose at least one crest elevation source!')
-#                 return
-#         else:
-#             return        
+                return       
         
         try:
             QApplication.setOverrideCursor(Qt.WaitCursor)
@@ -1156,7 +1144,7 @@ class Flo2D(object):
             for no in sorted(dlg_levee_elev.methods):
                 dlg_levee_elev.methods[no]()
             QApplication.restoreOverrideCursor()
-            self.uc.show_info('Values assigned!')
+            self.uc.show_info('Values assigned to the Schematic Levees layer!')
         except Exception as e:
             QApplication.restoreOverrideCursor()
             self.uc.log_info(traceback.format_exc())

--- a/flo2d/ui/levees_elevation.ui
+++ b/flo2d/ui/levees_elevation.ui
@@ -26,7 +26,16 @@
       <string>Levee crest elevation source</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
        <number>6</number>
       </property>
       <item>
@@ -106,7 +115,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Several changes to Levee Elevations Tool:
- User levee lines are required.
- Check boxes enabled if the layers exist.

- Better messages, warnings 