### PR TITLE
Green-ampt defaults assigned when no intersection of shapefile with cell

### DIFF
--- a/flo2d/db_structure.sql
+++ b/flo2d/db_structure.sql
@@ -2444,8 +2444,8 @@ CREATE TABLE "user_infiltration" (
     "green_char" TEXT DEFAULT 'F', --CHECK("green_char" = 'F' OR "green_char" = 'C')
     "hydc" REAL DEFAULT 0,
     "soils" REAL DEFAULT 0,
-    "dtheta" REAL DEFAULT 0,
-    "abstrinf" REAL DEFAULT 0,
+    "dtheta" REAL DEFAULT 0.3,
+    "abstrinf" REAL DEFAULT 0.1,
     "rtimpf" REAL DEFAULT 0,
     "soil_depth" REAL DEFAULT 0,
     "hydconch" REAL DEFAULT 0,


### PR DESCRIPTION
While computing Green-Ampt parameters, default values are assigned when shapefiles do not intersect cell