### PR TITLE
Cross-section table editor bug fix and enhancement

### DIFF
--- a/flo2d/ui/table_editor.ui
+++ b/flo2d/ui/table_editor.ui
@@ -14,7 +14,16 @@
    <string>FLO-2D Table Editor</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
     <number>6</number>
    </property>
    <item row="0" column="0">
@@ -60,6 +69,25 @@
          </property>
          <property name="text">
           <string>Import</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="delete_btn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>60</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Delete</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
The undo/redo function for natural cross-section was not working because cell values were not StandardItem.

Private functions to generate x,y coordinates for rectangular and trapezoidal user cross-section were added so that they can be ploted.

Added "delete" button in table editor widget to remove selected data row (s) from natural cross-section.

Cleaned up a bit table_editor_widget module and  XsecEditorWidget class.