### PR TITLE
Update schematic_tools.py

### DIFF
--- a/flo2d/flo2d_tools/schematic_tools.py
+++ b/flo2d/flo2d_tools/schematic_tools.py
@@ -2125,7 +2125,7 @@ class FloodplainXS(GeoPackageUtils):
             gid = self.grid_on_point(pnt.x(), pnt.y())
             geom = self.single_centroid(gid, buffers=True)
             yield (geom, gid)
-            distance += step
+            distance = min(length, distance + step)
             reps -= 1
 
     def schematize_floodplain_xs(self):


### PR DESCRIPTION
This fixes floodplain cross-section schematization error during interpolate_points calculation. The calculated "distance" may not be exactly equal to the line "length" for the last step.