### PR TITLE
Fix#780

### DIFF
--- a/flo2d/flo2d_ie/flo2dgeopackage.py
+++ b/flo2d/flo2d_ie/flo2dgeopackage.py
@@ -1516,7 +1516,6 @@ class Flo2dGeoPackage(GeoPackageUtils):
             else:
                 pass
 
-            max_arf = self.get_max("rain_arf_cells", "arf")
             rain = os.path.join(outdir, "RAIN.DAT")
             with open(rain, "w") as r:
 
@@ -1549,7 +1548,7 @@ class Flo2dGeoPackage(GeoPackageUtils):
 
                 if rain_row[5] == 1:  # if irainarf from rain = 0, omit this line.
                     for row in self.execute(rain_cells_sql):
-                        r.write(cell_line5.format(row[0], "{0:.3f}".format(row[1] / max_arf)))
+                        r.write(cell_line5.format(row[0], "{0:.3f}".format(row[1])))
 
             return True
 

--- a/flo2d/gui/dlg_sampling_rain.py
+++ b/flo2d/gui/dlg_sampling_rain.py
@@ -164,8 +164,14 @@ class SamplingRainDialog(qtBaseClass, uiDialog):
         else:
             pass
         sampler = raster2grid(self.grid, self.out_raster)
+
         qry = """INSERT INTO rain_arf_cells (arf, grid_fid) VALUES (?,?);"""
         self.con.executemany(qry, sampler)
+        qry = """SELECT MAX(arf) FROM rain_arf_cells;"""
+        max_val = self.con.execute(qry).fetchone()[0]
+        if max_val > 0:
+            qry = """UPDATE rain_arf_cells SET arf = arf/{0};""".format(max_val)
+            self.con.execute(qry)
         self.con.commit()
         return True
 

--- a/flo2d/gui/dlg_sampling_rain.py
+++ b/flo2d/gui/dlg_sampling_rain.py
@@ -136,8 +136,6 @@ class SamplingRainDialog(qtBaseClass, uiDialog):
             "-of GTiff",
             "-ot {}".format(self.RTYPE[self.raster_type]),
             "-tr {0} {0}".format(self.cell_size),
-            '-s_srs "{}"'.format(self.src_srs),
-            '-t_srs "{}"'.format(self.out_srs),
             "-te {}".format(" ".join([str(c) for c in self.output_bounds])),
             '-te_srs "{}"'.format(self.out_srs),
             "-dstnodata {}".format(self.src_nodata),
@@ -145,6 +143,12 @@ class SamplingRainDialog(qtBaseClass, uiDialog):
             "-co COMPRESS=LZW",
             "-wo OPTIMIZE_SIZE=TRUE",
         ]
+
+        if len(self.src_srs) > 0:
+            opts.append('-s_srs "{}"'.format(self.src_srs))
+        if len(self.out_srs) > 0:
+            opts.append('-t_srs "{}"'.format(self.out_srs))
+
         if self.multiThreadChBox.isChecked():
             opts.append("-multi -wo NUM_THREADS=ALL_CPUS")
         else:

--- a/flo2d/gui/rain_editor_widget.py
+++ b/flo2d/gui/rain_editor_widget.py
@@ -469,7 +469,7 @@ class RainEditorWidget(qtBaseClass, uiDialog):
         except Exception as e:
             QApplication.restoreOverrideCursor()
             self.uc.log_info(traceback.format_exc())
-            self.uc.show_warn("WARNING 060319.1726: Probing grid elevation failed! Please check your raster layer.")
+            self.uc.show_warn("WARNING 060319.1726: Probing grid rain failed! Please check your raster layer.")
 
     def get_cell_size(self):
         """


### PR DESCRIPTION
This PR make considering always the ratio factor for rain ARF in tables. When sampling from a rain raster, instead of considering and storing in the "Rain ARF Cells"  depth values, this new approach calculate the factor ratio directly and store it in the table.

Then, when exporting there is no need to recalculate the ratio.

