### PR TITLE
fix #808

### DIFF
--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -2560,8 +2560,7 @@ def render_grid_elevations2(elevs_lyr, show_nodata, mini, mini2, maxi):
         myRange = QgsRendererRange(low,maxi, symbol, '{0:.2f}'.format(low) + ' - ' + '{0:.2f}'.format(maxi))                   
         myRangeList.append(myRange)
 
-        myRenderer = QgsGraduatedSymbolRenderer("elevation", myRangeList)  
-        myRenderer.setMode(QgsGraduatedSymbolRenderer.Custom)               
+        myRenderer = QgsGraduatedSymbolRenderer("elevation", myRangeList)
     
         elevs_lyr.setRenderer(myRenderer)  
         elevs_lyr.triggerRepaint()

--- a/flo2d/gui/dlg_settings.py
+++ b/flo2d/gui/dlg_settings.py
@@ -107,7 +107,7 @@ class SettingsDialog(qtBaseClass, uiDialog):
                 pass
         proj = self.gutils.get_cont_par("PROJ")
         cs = QgsCoordinateReferenceSystem()
-        cs.createFromProj4(proj)
+        cs.createFromProj(proj)
         self.projectionSelector.setCrs(cs)
         self.crs = self.projectionSelector.crs()
         if self.gutils.get_cont_par("METRIC") == "1":


### PR DESCRIPTION
fix warnings due to use of deprecated QGIS methods.

Other warning in #808 seems to come from other plugin, so not related directly flo2d plugin.
One of other is related to pygtgraph wheel that need to be upgraded