### PR TITLE
avoid dupplicate levee line

### DIFF
--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -938,6 +938,9 @@ def calculate_spatial_variable_from_lines(grid, lines, request=None):
         features = grid.getFeatures() if request is None else grid.getFeatures(request)
         for feat in features:  # for each grid feature
             geom = feat.geometry()  # cell square (a polygon)
+            cellCentroid=geom.centroid()
+            if cellCentroid is None or not request.filterRect().contains(cellCentroid.asPoint()):
+                continue
             gelev = feat['elevation']
             fids = index.intersects(geom.boundingBox())  # c
             for fid in fids:


### PR DESCRIPTION
fix https://github.com/FLO-2DSoftware/qgis-flo-2d-plugin/issues/779#issuecomment-1123631849

Instead of removing the duplicate levees at the end of the process, this fix avoids duplicate levees during the process, so no need to remove them at the end.