### PR TITLE
Fix #844

### DIFF
--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -416,7 +416,11 @@ def intersection_spatial_index(vlayer, request=None):
     """
     allfeatures = {}
     index = QgsSpatialIndex()
-    max_fid = max(vlayer.allFeatureIds()) + 1
+    all_feature_id = vlayer.allFeatureIds()
+    if len(all_feature_id) == 0:
+        return allfeatures, index
+    max_fid = max(all_feature_id) + 1
+
     for feat in vlayer.getFeatures() if request is None else vlayer.getFeatures(request):
         geom = feat.geometry()
         if not geom.isGeosValid():
@@ -720,7 +724,7 @@ def poly2poly_geos(base_polygons, polygons, request=None, *columns):
 
     allfeatures, index = intersection_spatial_index(polygons) if request is None else intersection_spatial_index(polygons, request)
 
-    return poly2poly_geos_from_features(base_polygons, allfeatures, index, request=request, *columns)
+    return poly2poly_geos_from_features(base_polygons, allfeatures, index, request, *columns)
 
 
 
@@ -732,31 +736,32 @@ def poly2poly_geos_from_features(base_polygons, polygons_features, polygon_spati
     base_features = base_polygons.getFeatures() if request is None else base_polygons.getFeatures(request)
     for feat in base_features:
         base_geom = feat.geometry()
-        fids = polygon_spatial_index.intersects(base_geom.boundingBox())
-        if not fids:
-            continue
         base_fid = feat.id()
-        base_area = base_geom.area()
-        base_geom_geos = base_geom.constGet()
-        base_geom_engine = QgsGeometry.createGeometryEngine(base_geom_geos)
-        base_geom_engine.prepareGeometry()
         base_parts = []
-        for fid in fids:
-            f, other_geom_engine = polygons_features[fid]
-            inter = other_geom_engine.intersects(base_geom_geos)
-            if inter is False:
-                continue
-            if other_geom_engine.contains(base_geom_geos):
-                subarea = 1
-            elif base_geom_engine.contains(f.geometry().constGet()):
-                subarea = other_geom_engine.area() / base_area
-            else:
-                intersection_geom = other_geom_engine.intersection(base_geom_geos)
-                if not intersection_geom:
+        fids = polygon_spatial_index.intersects(base_geom.boundingBox())
+        if fids:
+            base_area = base_geom.area()
+            base_geom_geos = base_geom.constGet()
+            base_geom_engine = QgsGeometry.createGeometryEngine(base_geom_geos)
+            base_geom_engine.prepareGeometry()
+
+            for fid in fids:
+                f, other_geom_engine = polygons_features[fid]
+                inter = other_geom_engine.intersects(base_geom_geos)
+                if inter is False:
                     continue
-                subarea = intersection_geom.area() / base_area
-            values = tuple(f[col] for col in columns) + (subarea,)
-            base_parts.append(values)
+                if other_geom_engine.contains(base_geom_geos):
+                    subarea = 1
+                elif base_geom_engine.contains(f.geometry().constGet()):
+                    subarea = other_geom_engine.area() / base_area
+                else:
+                    intersection_geom = other_geom_engine.intersection(base_geom_geos)
+                    if not intersection_geom:
+                        continue
+                    subarea = intersection_geom.area() / base_area
+                values = tuple(f[col] for col in columns) + (subarea,)
+                base_parts.append(values)
+
         yield base_fid, base_parts
 
 
@@ -1218,6 +1223,7 @@ def gridRegionGenerator(gutils, grid, gridSpan = 100, regionPadding = 50, showPr
                         break
                     progress = regionCounter/regionCount * 100.0
                     progDialog.setValue(progress)
+                    QApplication.processEvents()
                 print ("Processing region: %s of %s" % (regionCounter, regionCount))
                 yield request
             if showProgress == True:

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1204,8 +1204,10 @@ def gridRegionGenerator(gutils, grid, gridSpan = 100, regionPadding = 50, showPr
     if showProgress == True:
         progDialog = QProgressDialog("Processing Progress (by area - timing will be uneven)", "Cancel", 0, 100)
         progDialog.setModal(True)
+        progDialog.setValue(0)
+        progDialog.show()
+        QApplication.processEvents()
 
-        progress = 0.0
     while regionCounter < regionCount:
         for row in range(rowCount):
             yMin = gridExt.yMinimum() + ySpan / rowCount * row - regionPadding / 2.0
@@ -1221,8 +1223,7 @@ def gridRegionGenerator(gutils, grid, gridSpan = 100, regionPadding = 50, showPr
                 if showProgress == True:
                     if progDialog.wasCanceled() == True:
                         break
-                    progress = regionCounter/regionCount * 100.0
-                    progDialog.setValue(progress)
+                    progDialog.setValue(regionCounter/regionCount * 100.0)
                     QApplication.processEvents()
                 print ("Processing region: %s of %s" % (regionCounter, regionCount))
                 yield request

--- a/flo2d/flo2d_tools/infiltration_tools.py
+++ b/flo2d/flo2d_tools/infiltration_tools.py
@@ -7,7 +7,7 @@
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version
-from math import log, exp, log10
+from math import log, exp, log10, sqrt
 from qgis.core import QgsGeometry, QgsSpatialIndex, QgsFeature, QgsField, QgsFields, QgsProject, QgsRectangle, QgsFeatureRequest
 from qgis.PyQt.QtWidgets import QApplication
 from .grid_tools import poly2poly_geos_from_features, intersection_spatial_index, centroids2poly_geos, gridRegionGenerator
@@ -101,10 +101,13 @@ class InfiltrationCalculator(object):
             grid_params = {}
             green_ampt = GreenAmpt()
 
-            for request in gridRegionGenerator(self.gutils, self.grid_lyr, gridSpan=10, regionPadding=5, showProgress=True):
+            grid_element_count = self.grid_lyr.featureCount()
+            gris_span = int(max(sqrt(grid_element_count) /10,10))
+
+            for request in gridRegionGenerator(self.gutils, self.grid_lyr, gridSpan=gris_span, regionPadding=5, showProgress=True):
 
                 # calculate extent of concerned grid element
-                grid_elems=self.grid_lyr.getFeatures(request)
+                grid_elems = self.grid_lyr.getFeatures(request)
                 grid_elem_extent = QgsRectangle()
                 grid_elem_extent.setMinimal()
                 for grid_elem in grid_elems:
@@ -126,47 +129,24 @@ class InfiltrationCalculator(object):
 
                 for land_feat, engine in land_features.values():
                     land_rtimp = land_feat[self.rtimpl_fld]
-                    rtimp_geom = land_feat.geometry()
+                    land_geom = land_feat.geometry()
 
-                    soil_fids = soil_index.intersects(rtimp_geom.boundingBox())
+                    soil_fids = soil_index.intersects(land_geom.boundingBox())
                     for soil_fid in soil_fids:
                         soil_feat, soil_engine = soil_features[soil_fid]
                         soil_rtimp = soil_feat[self.rtimps_fld]
-                        if soil_rtimp > land_rtimp:
-                            rtimp_geom = rtimp_geom.difference(soil_feat.geometry())
+                        rtimp_geom = land_geom.intersection(soil_feat.geometry())
 
-                    if rtimp_geom.isEmpty():
-                        continue
-
-                    rtimp_feat = QgsFeature(rtimp_fields, rtimp_fid)
-                    rtimp_feat.setGeometry(rtimp_geom)
-                    rtimp_feat[0] = land_rtimp
-                    rtimp_features[rtimp_fid] = (rtimp_feat, QgsGeometry.createGeometryEngine(rtimp_geom.constGet()))
-                    rtimp_index.insertFeature(rtimp_feat)
-                    rtimp_fid = rtimp_fid + 1
-
-                rtimp_id_for_land = rtimp_fid - 1
-
-                for soil_feat, engine in soil_features.values():
-                    soil_rtimp = soil_feat[self.rtimps_fld]
-                    rtimp_geom = QgsGeometry(soil_feat.geometry())
-
-                    land_fids = rtimp_index.intersects(rtimp_geom.boundingBox())
-                    for land_fid in land_fids:
-                        if land_fid > rtimp_id_for_land:
+                        if rtimp_geom.isEmpty():
                             continue
-                        land_feat, land_engine = rtimp_features[land_fid]
-                        rtimp_geom = rtimp_geom.difference(land_feat.geometry())
 
-                    if rtimp_geom.isEmpty():
-                        continue
+                        rtimp_feat = QgsFeature(rtimp_fields, rtimp_fid)
 
-                    rtimp_feat = QgsFeature(rtimp_fields, rtimp_fid)
-                    rtimp_feat.setGeometry(rtimp_geom)
-                    rtimp_feat[0] = soil_rtimp
-                    rtimp_features[rtimp_fid] = (rtimp_feat, QgsGeometry.createGeometryEngine(rtimp_geom.constGet()))
-                    rtimp_index.insertFeature(rtimp_feat)
-                    rtimp_fid = rtimp_fid + 1
+                        rtimp_feat.setGeometry(rtimp_geom)
+                        rtimp_feat[0] = max(land_rtimp, soil_rtimp)
+                        rtimp_features[rtimp_fid] = (rtimp_feat, QgsGeometry.createGeometryEngine(rtimp_geom.constGet()))
+                        rtimp_index.insertFeature(rtimp_feat)
+                        rtimp_fid = rtimp_fid + 1
 
                 try:
                     soil_values = poly2poly_geos_from_features(

--- a/flo2d/gui/infil_editor_widget.py
+++ b/flo2d/gui/infil_editor_widget.py
@@ -573,6 +573,7 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
                     no_inter = ""
                     for nope in non_intercepted:
                         no_inter += "\n" + str(nope)
+                    QApplication.restoreOverrideCursor()
                     self.uc.show_info(
                         "WARNING 150119.0354: Calculating Green-Ampt parameters finished, but \n"
                         + str(len(non_intercepted))
@@ -592,12 +593,13 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
         except Exception as e:
             self.gutils.enable_geom_triggers()
             self.uc.log_info(traceback.format_exc())
-            QApplication.restoreOverrideCursor()
             self.uc.show_error(
                 "ERROR 051218.1839: Green-Ampt infiltration failed!. Please check data in your input layers."
                 + "\n__________________________________________________",
                 e,
             )
+
+        QApplication.restoreOverrideCursor()
 
     def calculate_scs(self):
         dlg = SCSDialog(self.iface, self.lyrs)


### PR DESCRIPTION
Fixes #844.
Also change a bit the calculation of RTIMP. Indeed, the modification introduced by #834 contains an error related to the intersection between soil layer and land use layer to calculate the max RTIMP.
This new approach can slow down the calculation but is necessary to have a good calculation of the intersection between soil and land use. The speed of the calculation is linked a lot to the complexity of soil and land use layers.
