### PR TITLE
Export SWMM.INP file: only select directory and force 'SWMM.INP' name

### DIFF
--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -1831,16 +1831,28 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
             INP_groups = OrderedDict()
 
             s = QSettings()
-            last_dir = s.value("FLO-2D/lastGdsDir", "")
-            swmm_file, __ = QFileDialog.getSaveFileName(
-                None, "Select SWMM output file to update", directory=last_dir, filter="SWMM.INP file (SWMM.INP)"
-            )
+            last_dir = s.value("FLO-2D/lastSWMMDir", "")
+            swmm_dir = QFileDialog.getExistingDirectory(
+                None, 
+                "Select directory where SWMM.INP file will be exported", 
+                directory=last_dir, 
+                options=QFileDialog.ShowDirsOnly)
 
-            if not swmm_file:
+            if not swmm_dir:
                 return
-
-            s.setValue("FLO-2D/lastGdsDir", os.path.dirname(swmm_file))
-            last_dir = s.value("FLO-2D/lastGdsDir", "")
+            
+            swmm_file = swmm_dir + r"\SWMM.INP"
+            if os.path.isfile(swmm_file):
+                if not self.uc.question(
+                    "SWMM.INP already exits.\n\n"
+                    + "Would you like to replace it?"
+                ):
+                    return
+                else:
+                    pass
+                
+            s.setValue("FLO-2D/lastSWMMDir", os.path.dirname(swmm_file))
+            last_dir = s.value("FLO-2D/lastSWMMDir", "")
 
             if os.path.isfile(swmm_file):
                 # File exist, therefore import groups:

--- a/flo2d/metadata.txt
+++ b/flo2d/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=FLO-2D
-version=0.10.93
+version=0.10.94
 qgisMinimumVersion=3.0
 qgisMaximumVersion=3.99
 description=FLO-2D tools for QGIS
@@ -9,8 +9,10 @@ email=jj@flo-2d.com
 about=QGIS tools for FLO-2D
 
 changelog=
+ <p>0.10.94
+  - Export SWMM.INP file: only select directory and force 'SWMM.INP' name.
  <p>0.10.93
-  - Create user and schematic reservoirs when importing INFLOW.DAT (with geometry).
+  - Highlight cell when clicking domain while using grid info tool.
  <p>0.10.92
   - Create user and schematic reservoirs when importing INFLOW.DAT (with geometry).
   - Fix issue #902: apply graphics mode when no inflow or rainfall is present.


### PR DESCRIPTION
When exporting SWMM.INP file, only the directory is selected. The name 'SWMM.INP' can't be changed. If the file already exists, a warning is shown.