### PR TITLE
Use windows backward slash instead of forward slash in paths

### DIFF
--- a/flo2d/gui/dlg_inlets.py
+++ b/flo2d/gui/dlg_inlets.py
@@ -1302,7 +1302,7 @@ class InflowTimeSeriesDialog(qtBaseClass, uiDialog):
         if not time_series_file:
             return
         s.setValue("FLO-2D/lastSWMMDir", os.path.dirname(time_series_file))
-        self.file_le.setText(time_series_file)
+        self.file_le.setText(os.path.normpath(time_series_file))
 
         # For future use
         try:

--- a/flo2d/gui/dlg_outfalls.py
+++ b/flo2d/gui/dlg_outfalls.py
@@ -758,8 +758,7 @@ class OutfallTimeSeriesDialog(qtBaseClass, uiDialog):
         if not time_series_file:
             return
         s.setValue("FLO-2D/lastSWMMDir", os.path.dirname(time_series_file))
-        self.file_le.setText(time_series_file)
-
+        self.file_le.setText(os.path.normpath(time_series_file))
         # For future use
         try:
             pass

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -2474,6 +2474,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
                                     swmm_inp_file.write(line1.format(*description))
                                     fileName = os.path.basename(row[2].strip())
                                     file = '"' + last_dir + "/" + fileName + '"'
+                                    file = os.path.normpath(file)
                                     lrow2 = [row[0], "FILE", file]
                                     swmm_inp_file.write(line2.format(*lrow2))
                                     swmm_inp_file.write("\n;")

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -1831,16 +1831,28 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
             INP_groups = OrderedDict()
 
             s = QSettings()
-            last_dir = s.value("FLO-2D/lastGdsDir", "")
-            swmm_file, __ = QFileDialog.getSaveFileName(
-                None, "Select SWMM output file to update", directory=last_dir, filter="SWMM.INP file (SWMM.INP)"
-            )
+            last_dir = s.value("FLO-2D/lastSWMMDir", "")
+            swmm_dir = QFileDialog.getExistingDirectory(
+                None, 
+                "Select directory where SWMM.INP file will be exported", 
+                directory=last_dir, 
+                options=QFileDialog.ShowDirsOnly)
 
-            if not swmm_file:
+            if not swmm_dir:
                 return
-
-            s.setValue("FLO-2D/lastGdsDir", os.path.dirname(swmm_file))
-            last_dir = s.value("FLO-2D/lastGdsDir", "")
+            
+            swmm_file = swmm_dir + r"\SWMM.INP"
+            if os.path.isfile(swmm_file):
+                if not self.uc.question(
+                    "SWMM.INP already exits.\n\n"
+                    + "Would you like to replace it?"
+                ):
+                    return
+                else:
+                    pass
+                
+            s.setValue("FLO-2D/lastSWMMDir", os.path.dirname(swmm_file))
+            last_dir = s.value("FLO-2D/lastSWMMDir", "")
 
             if os.path.isfile(swmm_file):
                 # File exist, therefore import groups:

--- a/flo2d/metadata.txt
+++ b/flo2d/metadata.txt
@@ -1,5 +1,6 @@
 [general]
 name=FLO-2D
+version=0.10.95
 qgisMinimumVersion=3.0
 qgisMaximumVersion=3.99
 description=FLO-2D tools for QGIS

--- a/flo2d/metadata.txt
+++ b/flo2d/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=FLO-2D
-version=0.10.94
+version=0.10.95
 qgisMinimumVersion=3.0
 qgisMaximumVersion=3.99
 description=FLO-2D tools for QGIS
@@ -9,6 +9,8 @@ email=jj@flo-2d.com
 about=QGIS tools for FLO-2D
 
 changelog=
+ <p>0.10.95
+  - Write file paths in [TIMESERIES] group (in SWMM.INP) with backslashes '\'
  <p>0.10.94
   - Export SWMM.INP file: only select directory and force 'SWMM.INP' name.
  <p>0.10.93

--- a/flo2d/metadata.txt
+++ b/flo2d/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=FLO-2D
-version=0.10.93
+version=0.10.94
 qgisMinimumVersion=3.0
 qgisMaximumVersion=3.99
 description=FLO-2D tools for QGIS
@@ -9,8 +9,10 @@ email=jj@flo-2d.com
 about=QGIS tools for FLO-2D
 
 changelog=
+ <p>0.10.94
+  - Export SWMM.INP file: only select directory and force 'SWMM.INP' name.
  <p>0.10.93
-  - Create user and schematic reservoirs when importing INFLOW.DAT (with geometry).
+  - Highlight cell when clicking domain while using grid info tool.
  <p>0.10.92
   - Create user and schematic reservoirs when importing INFLOW.DAT (with geometry).
   - Fix issue #902: apply graphics mode when no inflow or rainfall is present.


### PR DESCRIPTION
When selecting time series files for Inlets and Outfalls, the paths will have backward slashes '\' :

![imagen](https://user-images.githubusercontent.com/20424575/227299769-d0ab29a6-63b9-4124-82ba-cfbe84e6040a.png)

![imagen](https://user-images.githubusercontent.com/20424575/227298365-22f2c00a-4b31-4248-b29f-21ec45ba25b2.png)

As a consequence, the [TIMESERIES] group in SWMM.INP will also have the file paths with backward slashes.