### PR TITLE
Outfalls tidal curve hours as float number (not HH.MM)

### DIFF
--- a/flo2d/metadata.txt
+++ b/flo2d/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=FLO-2D
-version=0.10.97
+version=0.10.98
 qgisMinimumVersion=3.0
 qgisMaximumVersion=3.99
 description=FLO-2D tools for QGIS
@@ -9,6 +9,8 @@ email=jj@flo-2d.com
 about=QGIS tools for FLO-2D
 
 changelog=
+ <p>0.10.98
+  - Outfalls tidal curve hours as float number (not HH.MM as before).
  <p>0.10.97
   - Outfalls and Inlets TimeSeries: input validation for hours (HH:MM) and date (MM/DD/YYY).
  <p>0.10.96

--- a/flo2d/ui/storm_drain_outfall_tidal_curve.ui
+++ b/flo2d/ui/storm_drain_outfall_tidal_curve.ui
@@ -197,7 +197,7 @@
       </size>
      </property>
      <property name="inputMethodHints">
-      <set>Qt::ImhTime</set>
+      <set>Qt::ImhNone</set>
      </property>
      <property name="editTriggers">
       <set>QAbstractItemView::AllEditTriggers</set>
@@ -207,6 +207,9 @@
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
      </property>
      <property name="rowCount">
       <number>0</number>

--- a/flo2d/utils.py
+++ b/flo2d/utils.py
@@ -32,7 +32,29 @@ class NumericDelegate(QStyledItemDelegate):
     def createEditor(self, parent, option, index):
         editor = super(NumericDelegate, self).createEditor(parent, option, index)
         if isinstance(editor, QLineEdit):
-            reg_ex = QRegExp("[0-9]+.?[0-9]{,4}")
+            reg_ex = QRegExp("[0-9]+.4[0-9]")
+            validator = QRegExpValidator(reg_ex, editor)
+            editor.setValidator(validator)
+        return editor
+    
+    # def paint(self, painter, option, index):
+    #     value = index.model().data(index, Qt.EditRole)
+    #     try:
+    #         number = float(value)
+    #         # painter.drawText(option.rect, Qt.AlignLeft, f"{value:.4f}")
+    #         painter.drawText(option.rect, Qt.AlignLeft, "{5f.{}4f}".format(number))
+    #     except :
+    #         QStyledItemDelegate.paint(self, painter, option, index)
+
+    # def displayText(self,value,locale):
+    #     return f"{value:.4f}"
+    
+    
+class NumericDelegate2(QStyledItemDelegate):
+    def createEditor(self, parent, option, index):
+        editor = super(NumericDelegate2, self).createEditor(parent, option, index)
+        if isinstance(editor, QLineEdit):
+            reg_ex = QRegExp("[0-9]?[0-9]*[.][0-5][0-9]")
             validator = QRegExpValidator(reg_ex, editor)
             editor.setValidator(validator)
         return editor
@@ -41,10 +63,10 @@ class NumericDelegate(QStyledItemDelegate):
         value = index.model().data(index, Qt.EditRole)
         try:
             number = float(value)
-            painter.drawText(option.rect, Qt.AlignLeft, "{:.{}f}".format(number, 5))
+            painter.drawText(option.rect, Qt.AlignLeft, "{:.{}f}".format(number, 2))
         except :
-            QStyledItemDelegate.paint(self, painter, option, index)
-             
+            QStyledItemDelegate.paint(self, painter, option, index)   
+                      
 class HourDelegate(QStyledItemDelegate):
     def createEditor(self, parent, option, index):
         editor = super(HourDelegate, self).createEditor(parent, option, index)
@@ -92,6 +114,27 @@ class TimeSeriesDelegate(QStyledItemDelegate):
                 validator = QRegExpValidator(reg_ex, editor)
                 editor.setValidator(validator)            
         return editor
+
+class FloatDelegate(QItemDelegate):
+    def __init__(self, decimals, parent=None):
+        QItemDelegate.__init__(self, parent=parent)
+        self.nDecimals = decimals
+
+    def createEditor(self, parent, option, index):
+        editor = super(FloatDelegate, self).createEditor(parent, option, index)
+        if isinstance(editor, QLineEdit):
+            reg_ex = QRegExp("[^a-zA-Z!·$%&/()=?¿><;:_¡^*][0-9]*\.?[0-9]*")
+            validator = QRegExpValidator(reg_ex, editor)
+            editor.setValidator(validator)
+        return editor
+    
+    def paint(self, painter, option, index):
+        value = index.model().data(index, Qt.EditRole)
+        try:
+            number = float(value)
+            painter.drawText(option.rect, Qt.AlignLeft, "{.3f}".format(number, self.nDecimals ))
+        except :
+            QItemDelegate.paint(self, painter, option, index)
 
 def get_BC_Border():
     global BC_BORDER


### PR DESCRIPTION
- First column of tidal curve table (hours) accepts real numbers.
- Items in Tidal curve table is loaded in ascending order by first column (hours).
- Cells of table only accepts digits, period and minus sign.