### PR TITLE
Remove/Improve multiple channel messages when exporting GDS files

### DIFF
--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -238,20 +238,20 @@ class ComponentsDialog(qtBaseClass, uiDialog):
                 self.levees_chbox.setEnabled(True)
 
             # Multiple channels:
-            # if options["IMULTC"] == "1":
-            if self.gutils.is_table_empty("mult_cells") and self.gutils.is_table_empty("simple_mult_cells"):
-                QApplication.restoreOverrideCursor()
-                self.uc.show_info(
-                    "WARNING 130222.0843: there aren't mult channels or simple mult channels in the project!\n\nThe IMULTC switch will be turned off."
-                )
-                self.gutils.set_cont_par("IMULTC", 0)
-                QApplication.setOverrideCursor(Qt.WaitCursor)
-            else:  # There are Mult or simple channels cells:
-                if self.gutils.is_table_empty("mult"):
-                    # There are mult or simple channels but 'mult' (globals) is empty: set globals:
-                    self.gutils.fill_empty_mult_globals()
-                self.multiple_channels_chbox.setChecked(True)
-                self.multiple_channels_chbox.setEnabled(True)
+            if options["IMULTC"] == "1":
+                if self.gutils.is_table_empty("mult_cells") and self.gutils.is_table_empty("simple_mult_cells"):
+                    QApplication.restoreOverrideCursor()
+                    self.uc.show_info(
+                        "WARNING 130222.0843: there aren't mult channels or simple mult channels in the project!\n\nThe IMULTC switch will be turned off."
+                    )
+                    self.gutils.set_cont_par("IMULTC", 0)
+                    QApplication.setOverrideCursor(Qt.WaitCursor)
+                else:  # There are Mult or simple channels cells:
+                    if self.gutils.is_table_empty("mult"):
+                        # There are mult or simple channels but 'mult' (globals) is empty: set globals:
+                        self.gutils.fill_empty_mult_globals()
+                    self.multiple_channels_chbox.setChecked(True)
+                    self.multiple_channels_chbox.setEnabled(True)
 
             if not self.gutils.is_table_empty("breach"):
                 self.breach_chbox.setChecked(True)

--- a/flo2d/metadata.txt
+++ b/flo2d/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=FLO-2D
-version=0.10.108
+version=0.10.109
 qgisMinimumVersion=3.0
 qgisMaximumVersion=3.99
 description=FLO-2D tools for QGIS
@@ -9,6 +9,8 @@ email=jj@flo-2d.com
 about=QGIS tools for FLO-2D
 
 changelog=
+ <p>0.10.109
+  - Remove/Improve multiple channel messages when exporting GDS files.
  <p>0.10.108
   - Remove tailings dam_breach tool from FLO-2D toolbar.
  <p>0.10.107


### PR DESCRIPTION
Only show a warning message if  IMULT switch is set and there are no 'mult_cells' or 'simple_mult_cells' features. 