### PR TITLE
SD pumps: initial status error catching and correction

### DIFF
--- a/flo2d/db_structure.sql
+++ b/flo2d/db_structure.sql
@@ -1407,7 +1407,7 @@ CREATE TABLE "swmm_time_series" (
     "time_series_name" TEXT, -- 
     "time_series_description" TEXT, -- 
     "time_series_file" TEXT,
-	"time_series_data" TEXT DEFAULT "False"-- 
+	"time_series_data" TEXT DEFAULT 'False'-- 
 );
 INSERT INTO gpkg_contents (table_name, data_type) VALUES ('swmm_time_series', 'aspatial');
 
@@ -1470,7 +1470,7 @@ CREATE TABLE "user_swmm_pumps" (
     "pump_inlet" TEXT,
     "pump_outlet" TEXT,
     "pump_curve" TEXT,
-    "pump_init_status" Text DEFAULT 'False',   
+    "pump_init_status" Text DEFAULT 'OFF',   
     "pump_startup_depth" REAL DEFAULT 0.0,  
     "pump_shutoff_depth" REAL DEFAULT 0.0
 );
@@ -1494,12 +1494,12 @@ CREATE TABLE "user_swmm_orifices" (
     "orifice_name" TEXT,                        -- [ORIFICES]
     "orifice_inlet" TEXT,                       -- [ORIFICES]
     "orifice_outlet" TEXT,                      -- [ORIFICES]
-    "orifice_type" TEXT DEFAULT "SIDE",         -- [ORIFICES]
+    "orifice_type" TEXT DEFAULT 'SIDE',         -- [ORIFICES]
     "orifice_crest_height" REAL DEFAULT 0.0,    -- [ORIFICES]   
     "orifice_disch_coeff" REAL DEFAULT 0.0,     -- [ORIFICES]  
-    "orifice_flap_gate" TEXT DEFAULT "NO",      -- [ORIFICES]
+    "orifice_flap_gate" TEXT DEFAULT 'NO',      -- [ORIFICES]
     "orifice_open_close_time" REAL DEFAULT 0.0, -- [ORIFICES]
-    "orifice_shape" TEXT DEFAULT "CIRCULAR",    -- [XSECTIONS] 
+    "orifice_shape" TEXT DEFAULT 'CIRCULAR',    -- [XSECTIONS] 
     "orifice_height" REAL DEFAULT 0.0,          -- [XSECTIONS] Geom1
     "orifice_width" REAL DEFAULT 0.0            -- [XSECTIONS] Geom2   
 );
@@ -1516,7 +1516,7 @@ CREATE TABLE "user_swmm_weirs" (
     "weir_type" TEXT,                          -- [WEIRS]
     "weir_crest_height" REAL DEFAULT 0.0,      -- [WEIRS] Inlet Offset in EPA SWMM
     "weir_disch_coeff" REAL DEFAULT 0.0,       -- [WEIRS] 
-    "weir_flap_gate" TEXT DEFAULT "NO",        -- [WEIRS]
+    "weir_flap_gate" TEXT DEFAULT 'NO',        -- [WEIRS]
     "weir_end_contrac" TEXT DEFAULT "0",       -- [WEIRS]
     "weir_end_coeff" REAL DEFAULT 0.0,         -- [WEIRS]
     "weir_shape" TEXT,                         -- [XSECTION] 

--- a/flo2d/gui/dlg_pumps.py
+++ b/flo2d/gui/dlg_pumps.py
@@ -248,13 +248,32 @@ class PumpsDialog(qtBaseClass, uiDialog):
                 index = 0
             self.pump_curve_cbo.setCurrentIndex(index)
 
+
+
             status = self.pumps_tblw.item(row, 4).text()
-            if status.isdigit():
-                index = int(status) - 1
-                index = 1 if index > 1 else 0 if index < 0 else index
-            else:
-                index = 0 if status == "ON" else 1
+            index = self.pump_init_status_cbo.findText(status)
+            if index == -1:
+                index = 1 # Select default "OFF".
+                self.pumps_tblw.item(row, 4).setText("OFF")
+                self.uc.bar_warn("WARNING 261128.0542: pump '" + name  + "' has wrong status '" + status + "'. Changed to default 'OFF'")                
             self.pump_init_status_cbo.setCurrentIndex(index)
+
+
+
+
+            # status = self.pumps_tblw.item(row, 4).text()
+            # if status.isdigit():
+            #     index = int(status) - 1
+            #     index = 1 if index > 1 else 0 if index < 0 else index
+            # else:
+            #     index = 0 if status == "ON" else 1
+            # self.pump_init_status_cbo.setCurrentIndex(index)
+
+
+
+
+
+
 
             self.startup_depth_dbox.setValue(float_or_zero(self.pumps_tblw.item(row, 5).text()))
             self.shutoff_depth_dbox.setValue(float(self.pumps_tblw.item(row, 6).text()))


### PR DESCRIPTION
- SD pumps dialog corrects initial status variable when not ON or OFF in table.
- Also all TEXT fields defaults in tables in db_structure.sql changed to single quotes from double quotes where applicable.