### PR TITLE
Added "FLOPRO not found" when the user creates a database without having FLO-2D installed

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -1123,6 +1123,7 @@ class Flo2D(object):
                 s.setValue("FLO-2D/run_settings", True)
 
                 flopro_dir = s.value("FLO-2D/last_flopro")
+                flo2d_v = "FLOPRO not found"
                 # Check for FLOPRO.exe
                 if os.path.isfile(flopro_dir + "/FLOPRO.exe"):
                     flo2d_v = get_flo2dpro_version(flopro_dir + "/FLOPRO.exe")
@@ -1324,6 +1325,7 @@ class Flo2D(object):
 
             QApplication.restoreOverrideCursor()
             flopro_dir = s.value("FLO-2D/last_flopro")
+            flo2d_v = "FLOPRO not found"
             if flopro_dir is not None:
                 # Check for FLOPRO.exe
                 if os.path.isfile(flopro_dir + "/FLOPRO.exe"):
@@ -1344,6 +1346,7 @@ class Flo2D(object):
         self.uncheck_all_info_tools()
         s = QSettings()
         flopro_dir = s.value("FLO-2D/last_flopro")
+        flo2d_v = "FLOPRO not found"
         # Check if the FLOPRO directory is in the FLO-2D Settings
         if flopro_dir is not None:
             # Check if the user has the FLOPRO version

--- a/flo2d/gui/dlg_settings.py
+++ b/flo2d/gui/dlg_settings.py
@@ -346,6 +346,9 @@ class SettingsDialog(qtBaseClass, uiDialog):
         contact = QgsProject.instance().metadata().author()
         plugin_v = get_plugin_version()
         qgis_v = qgis.core.Qgis.QGIS_VERSION
+        # Referencing the variable before. It will be updated if there is a FLOPRO.exe or FLOPRO_Demo.exe if FLO-2D is
+        # installed correctly on the user's computer
+        flo2d_v = "FLOPRO not found"
 
         flopro_dir = s.value("FLO-2D/last_flopro")
         if flopro_dir is not None:

--- a/flo2d/gui/dlg_update_gpkg.py
+++ b/flo2d/gui/dlg_update_gpkg.py
@@ -72,6 +72,7 @@ class UpdateGpkg(qtBaseClass, uiDialog):
         self.label_qv.setText(qgis_v)
 
         flopro_dir = s.value("FLO-2D/last_flopro")
+        flo2d_v = "FLOPRO not found"
         if os.path.isfile(flopro_dir + "/FLOPRO.exe"):
             flo2d_v = get_flo2dpro_version(flopro_dir + "/FLOPRO.exe")
         # Check for the FLOPRO_Demo


### PR DESCRIPTION
Fixed that in others situations where the flo2d version is written to the metadata.