### PR TITLE
#1035 examine all center checkboxes in flo 2 d panel

### DIFF
--- a/flo2d/db_structure.sql
+++ b/flo2d/db_structure.sql
@@ -2347,7 +2347,7 @@ SELECT gpkgAddGeometryTriggers('user_levee_lines', 'geom');
 
 CREATE TABLE "user_streets" (
     "fid" INTEGER PRIMARY KEY NOT NULL,
-    "name" TEXT DEFAULT '',
+    "name" TEXT,
     "n_value" REAL DEFAULT 0, -- STMAN(L), optional spatially variable street n-value within a given grid element. 0 for global
     "elevation" REAL DEFAULT 0, -- ELSTR(L), optional street elevation. If 0, the model will assign the street elevation as grid element elevation
     "curb_height" REAL DEFAULT 0, -- DEPX(L) or DEPEX(L), optional curb height, 0 to use global DEPX
@@ -2358,6 +2358,15 @@ INSERT INTO gpkg_contents (table_name, data_type, srs_id) VALUES ('user_streets'
 SELECT gpkgAddGeometryColumn('user_streets', 'geom', 'LINESTRING', 0, 0, 0);
 SELECT gpkgAddGeometryTriggers('user_streets', 'geom');
 -- SELECT gpkgAddSpatialIndex('user_streets', 'geom');
+
+INSERT INTO trigger_control (name, enabled) VALUES ('default_street_name', 1);
+CREATE TRIGGER "default_street_name"
+    AFTER INSERT ON "user_streets"
+    BEGIN
+        UPDATE "user_streets"
+        SET name = ('Street_' || cast(NEW."fid" AS TEXT))
+        WHERE "fid" = NEW."fid" AND NEW."name" IS NULL;
+    END;
 
 CREATE TABLE "user_roughness" (
     "fid" INTEGER PRIMARY KEY NOT NULL,

--- a/flo2d/gui/ic_editor_widget.py
+++ b/flo2d/gui/ic_editor_widget.py
@@ -104,7 +104,7 @@ class ICEditorWidget(qtBaseClass, uiDialog):
             wsel = float(self.reservoir.wsel)
         self.res_ini_sbox.setValue(wsel)
         self.show_res_rb()
-        if self.center_res_chbox.isChecked():
+        if self.center_res_btn.isChecked():
             feat = next(self.res_lyr.getFeatures(QgsFeatureRequest(self.reservoir.fid)))
             x, y = feat.geometry().centroid().asPoint()
             center_canvas(self.iface, x, y)
@@ -118,7 +118,7 @@ class ICEditorWidget(qtBaseClass, uiDialog):
             depini = float(di[0])
         self.seg_ini_sbox.setValue(depini)
         self.show_chan_rb()
-        if self.center_seg_chbox.isChecked():
+        if self.center_seg_btn.isChecked():
             feat = next(self.chan_lyr.getFeatures(QgsFeatureRequest(self.seg_fid)))
             x, y = feat.geometry().centroid().asPoint()
             center_canvas(self.iface, x, y)

--- a/flo2d/gui/infil_editor_widget.py
+++ b/flo2d/gui/infil_editor_widget.py
@@ -398,7 +398,7 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
                 else:
                     continue
         self.lyrs.clear_rubber()
-        if self.center_chbox.isChecked():
+        if self.infil_center_btn.isChecked():
             ifid = infil_dict["fid"]
             self.lyrs.show_feat_rubber(self.infil_lyr.id(), ifid)
             feat = next(self.infil_lyr.getFeatures(QgsFeatureRequest(ifid)))

--- a/flo2d/gui/street_editor_widget.py
+++ b/flo2d/gui/street_editor_widget.py
@@ -99,11 +99,14 @@ class StreetEditorWidget(qtBaseClass, uiDialog):
         else:
             return
         self.lyrs.clear_rubber()
-        if self.street_center_chbox.isChecked():
-            self.lyrs.show_feat_rubber(self.street_lyr.id(), fid)
-            feat = next(self.street_lyr.getFeatures(QgsFeatureRequest(fid)))
-            x, y = feat.geometry().centroid().asPoint()
-            center_canvas(self.iface, x, y)
+        if self.street_center_btn.isChecked():
+            try:
+                self.lyrs.show_feat_rubber(self.street_lyr.id(), fid)
+                feat = next(self.street_lyr.getFeatures(QgsFeatureRequest(fid)))
+                x, y = feat.geometry().centroid().asPoint()
+                center_canvas(self.iface, x, y)
+            except:
+                pass  
 
     def create_street_line(self):
         if not self.lyrs.enter_edit_mode("user_streets"):

--- a/flo2d/ui/ic_editor.ui
+++ b/flo2d/ui/ic_editor.ui
@@ -70,9 +70,16 @@
          </spacer>
         </item>
         <item>
-         <widget class="QCheckBox" name="center_res_chbox">
+         <widget class="QToolButton" name="center_res_btn">
           <property name="text">
-           <string>center</string>
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>../img/eye-svgrepo-com.svg</normaloff>../img/eye-svgrepo-com.svg</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -233,9 +240,16 @@
          </spacer>
         </item>
         <item>
-         <widget class="QCheckBox" name="center_seg_chbox">
+         <widget class="QToolButton" name="center_seg_btn">
           <property name="text">
-           <string>center</string>
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>../img/eye-svgrepo-com.svg</normaloff>../img/eye-svgrepo-com.svg</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -642,11 +656,11 @@
   <tabstop>revert_changes_btn</tabstop>
   <tabstop>delete_res_btn</tabstop>
   <tabstop>schem_res_btn</tabstop>
-  <tabstop>center_res_chbox</tabstop>
+  <tabstop>center_res_btn</tabstop>
   <tabstop>res_cbo</tabstop>
   <tabstop>rename_res_btn</tabstop>
   <tabstop>res_ini_sbox</tabstop>
-  <tabstop>center_seg_chbox</tabstop>
+  <tabstop>center_seg_btn</tabstop>
   <tabstop>chan_seg_cbo</tabstop>
   <tabstop>seg_ini_sbox</tabstop>
   <tabstop>add_tailings_btn</tabstop>

--- a/flo2d/ui/infil_editor.ui
+++ b/flo2d/ui/infil_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>455</height>
+    <height>582</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -230,7 +230,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="center_chbox">
+      <widget class="QToolButton" name="infil_center_btn">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -238,7 +238,14 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Center</string>
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>../img/eye-svgrepo-com.svg</normaloff>../img/eye-svgrepo-com.svg</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
        <property name="checked">
         <bool>false</bool>

--- a/flo2d/ui/street_editor.ui
+++ b/flo2d/ui/street_editor.ui
@@ -230,15 +230,28 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="street_center_chbox">
+      <widget class="QToolButton" name="street_center_btn">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>31</width>
+         <height>30</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Center</string>
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>../img/eye-svgrepo-com.svg</normaloff>../img/eye-svgrepo-com.svg</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
        <property name="checked">
         <bool>false</bool>


### PR DESCRIPTION
Changes to 'Center' buttons of Street Editor, Infiltration Editor, and Initial Conditions Editor widgets:

- Change 'center' QCheckBox to QToolButton.
- Make them checkable.
- Set icon to 'eye' (eye-svgrepo-com.svg).
- Modify needed code in respective classes.