### PR TITLE
Hide (disabled) columns in q table widgets

### DIFF
--- a/flo2d/gui/dlg_inlets.py
+++ b/flo2d/gui/dlg_inlets.py
@@ -67,6 +67,8 @@ class InletNodesDialog(qtBaseClass, uiDialog):
         set_icon(self.zoom_in_inlet_btn, "zoom_in.svg")
         set_icon(self.zoom_out_inlet_btn, "zoom_out.svg")
 
+        self.inlets_tblw.horizontalHeader().hideSection(6)
+        
         self.save_this_inlet_btn.setVisible(False)
         self.inletRT = None
         self.plot = plot

--- a/flo2d/gui/dlg_storage_units.py
+++ b/flo2d/gui/dlg_storage_units.py
@@ -69,6 +69,8 @@ class StorageUnitsDialog(qtBaseClass, uiDialog):
         set_icon(self.zoom_out_storage_btn, "zoom_out.svg")
         set_icon(self.open_tabular_curve_btn, "open_dialog.svg")
 
+        self.storages_tblw.horizontalHeader().hideSection(6)
+
         self.save_this_storage_btn.setVisible(False)
         self.plot = plot
         self.table = table


### PR DESCRIPTION
Hide (disabled) column in table of Inlets/Junctions and Storage Units dialogs.

Previously, the (disabled) colummn was 'Ponded Area'