### PR TITLE
Set allow discharge to 0

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -3341,8 +3341,9 @@ class Flo2D(object):
         """
         Function to export FLO-2D to SWMM's INP file
         """
-        sd_editor = StormDrainEditorWidget(self.iface, self.f2d_plot, self.f2d_table, self.lyrs)
-        sd_editor.import_storm_drain_INP_file("Choose", True)
+        # sd_editor = StormDrainEditorWidget(self.iface, self.f2d_plot, self.f2d_table, self.lyrs)
+        # sd_editor.import_storm_drain_INP_file("Choose", True)
+        self.f2d_widget.storm_drain_editor.import_storm_drain_INP_file("Choose", True)
 
     @connection_required
     def export_inp(self):

--- a/flo2d/flo2d_ie/swmm_io.py
+++ b/flo2d/flo2d_ie/swmm_io.py
@@ -1016,7 +1016,7 @@ class StormDrainProject(object):
                                 else:
                                     continue 
                         else:
-                            description = ""
+                            # description = ""
                             continue    
                            
                     items = c.split()

--- a/flo2d/gui/dlg_outfalls.py
+++ b/flo2d/gui/dlg_outfalls.py
@@ -160,13 +160,6 @@ class OutfallNodesDialog(qtBaseClass, uiDialog):
                 QApplication.restoreOverrideCursor()
                 return
 
-            # # Replace 'swmm_allow_discharge' with 'outf_flo' of 'swmmoutf' table:
-            # outf_flo_qry = "SELECT outf_flo FROM swmmoutf WHERE name = ?;"
-                            
-            # for r in rows:
-            #     outf_flo = self.gutils.execute("SELECT outf_flo FROM swmmoutf WHERE name = ?;", (r[1],)).fetchone()
-            #     r[5] = outf_flo
-
             self.block = True
 
             # Fill list of time series names:
@@ -211,12 +204,10 @@ class OutfallNodesDialog(qtBaseClass, uiDialog):
  
                     if col_number == 5:
                         outf_flo = self.gutils.execute(outf_flo_qry, (row_data[1],)).fetchone()
-                        item.setData(Qt.DisplayRole, outf_flo[0]) 
-
-                        
-                        
-                        # data = data if data in ["0", "1", "2"] else "0"
-                        # item.setData(Qt.DisplayRole, data) 
+                        if outf_flo:
+                            item.setData(Qt.DisplayRole, outf_flo[0]) 
+                        else:
+                            item.setData(Qt.DisplayRole, "0")   
 
                     # Fill all text boxes with data of first feature of query (first element in table user_swmm_nodes):
                     if row_number == 0:
@@ -231,8 +222,11 @@ class OutfallNodesDialog(qtBaseClass, uiDialog):
                         elif col_number == 5:
                             # self.allow_discharge_chbox.setChecked(True if is_true(data) else False)
                             outf_flo = self.gutils.execute(outf_flo_qry, (row_data[1],)).fetchone()
-                            # idx = self.allow_discharge_cbo.findText(outf_flo[0])
-                            self.allow_discharge_cbo.setCurrentIndex(outf_flo[0])                           
+                            
+                            if outf_flo:
+                                self.allow_discharge_cbo.setCurrentIndex(outf_flo[0])  
+                            else:
+                                self.allow_discharge_cbo.setCurrentIndex(0)                            
   
                         elif col_number == 6:
                             data = str(data).upper()

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -2692,10 +2692,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         self.pump_curve_cbo.blockSignals(True)
         self.update_pump_curve_data()
         self.pump_curve_cbo.blockSignals(False)
-        
 
-        self.uc.show_warn("hererererre")
-        
         QApplication.restoreOverrideCursor()
         return True
 

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -462,7 +462,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         self.pump_curve_description_le.textChanged.connect(self.update_pump_curve_data)
                
         self.pump_curve_cbo.activated.connect(self.current_cbo_pump_curve_index_changed)
-        self.pump_curve_cbo.currentIndexChanged.connect(self.refresh_PC_PlotAndTable)
+        # self.pump_curve_cbo.currentIndexChanged.connect(self.refresh_PC_PlotAndTable)
 
         self.simulate_stormdrain_chbox.clicked.connect(self.simulate_stormdrain)
         self.import_shapefile_btn.clicked.connect(self.import_hydraulics)
@@ -2692,6 +2692,9 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         self.pump_curve_cbo.blockSignals(True)
         self.update_pump_curve_data()
         self.pump_curve_cbo.blockSignals(False)
+        
+
+        self.uc.show_warn("hererererre")
         
         QApplication.restoreOverrideCursor()
         return True
@@ -5829,6 +5832,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         for i in range(self.pumps_data_model.rowCount()):
             self.tview.setRowHeight(i, 20)
         self.update_pump_plot()
+        self.show_pump_curve_type_and_description()
 
     def create_pump_plot(self, name):
         self.plot.clear()

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -3842,7 +3842,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
 
         save = dlg_inlets.exec_()
         if save:
-            self.uc.show_info(
+            self.uc.bar_info(
                 "Inlets saved to 'Storm Drain-Inlets' User Layer!\n\n"
                 + "Schematize it from the 'Storm Drain Editor' widget before saving into SWMMOUTF.DAT"
             )

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -1377,7 +1377,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
                 flapgate = "True" if is_true(flapgate) else "False"
 
                 allow_discharge = values["swmm_allow_discharge"] if "swmm_allow_discharge" in values else "False"
-                allow_discharge = "True" if is_true(allow_discharge) else "False"
+                allow_discharge = "1" if is_true(allow_discharge) else "0"
 
                 rim_elev = junction_invert_elev + max_depth if junction_invert_elev and max_depth else 0
 

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -3804,10 +3804,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         if save:
             try:
                 dlg_outfalls.save_outfalls()
-                self.uc.bar_info(
-                    "Outfalls saved to 'Storm Drain-Outfalls' User Layer!\n\n"
-                    + "Schematize it from the 'Storm Drain Editor' widget before saving into SWMMOUTF.DAT"
-                )
+                self.uc.bar_info("Outfalls saved to 'Storm Drain-Outfalls' User Layer.")
             except Exception:
                 self.uc.bar_warn("Could not save outfalls! Please check if they are correct.")
                 return
@@ -3842,10 +3839,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
 
         save = dlg_inlets.exec_()
         if save:
-            self.uc.bar_info(
-                "Inlets saved to 'Storm Drain-Inlets' User Layer!\n\n"
-                + "Schematize it from the 'Storm Drain Editor' widget before saving into SWMMOUTF.DAT"
-            )
+            self.uc.bar_info("Inlets saved to 'Storm Drain-Inlets' User Layer.")
             self.populate_type4_combo()
 
         elif not save:
@@ -3903,10 +3897,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         if save:
             try:
                 dlg_conduits.save_conduits()
-                self.uc.bar_info(
-                    "Conduits saved to 'Storm Drain-Conduits' User Layer!\n\n"
-                    + "Schematize it from the 'Storm Drain Editor' widget before saving into SWMMOUTF.DAT"
-                )
+                self.uc.bar_info("Conduits saved to 'Storm Drain-Conduits' User Layer.")
             except Exception:
                 self.uc.bar_warn("Could not save conduits! Please check if they are correct.")
                 return
@@ -3933,10 +3924,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         if save:
             try:
                 dlg_pumps.save_pumps()
-                self.uc.bar_info(
-                    "Pumps saved to 'Storm Drain-Pumps' User Layer!\n\n"
-                    + "Schematize it from the 'Storm Drain Editor' widget before saving into SWMMOUTF.DAT"
-                )
+                self.uc.bar_info("Pumps saved to 'Storm Drain-Pumps' User Layer.")
             except Exception:
                 self.uc.bar_warn("Could not save pumps! Please check if they are correct.")
                 return
@@ -3963,10 +3951,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         if save:
             try:
                 dlg_orifices.save_orifices()
-                self.uc.bar_info(
-                    "Orifices saved to 'Storm Drain Orifices' User Layer!\n\n"
-                    + "Schematize it from the 'Storm Drain Editor' widget before saving into SWMMOUTF.DAT"
-                )
+                self.uc.bar_info("Orifices saved to 'Storm Drain Orifices' User Layer.")
             except Exception:
                 self.uc.bar_warn("Could not save orifices! Please check if they are correct.")
                 return
@@ -3993,10 +3978,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         if save:
             try:
                 dlg_weirs.save_weirs()
-                self.uc.bar_info(
-                    "Weirs saved to 'Storm Drain Weirs' User Layer!\n\n"
-                    + "Schematize it from the 'Storm Drain Editor' widget before saving into SWMMOUTF.DAT"
-                )
+                self.uc.bar_info("Weirs saved to 'Storm Drain Weirs' User Layer.")
             except Exception:
                 self.uc.bar_warn("Could not save weirs! Please check if they are correct.")
                 return

--- a/flo2d/ui/storm_drain_editor.ui
+++ b/flo2d/ui/storm_drain_editor.ui
@@ -602,7 +602,7 @@
            <enum>QComboBox::InsertAtBottom</enum>
           </property>
           <property name="duplicatesEnabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
To review/inspect before merging into master:

- [x] Loading the outfalls dialog set 'allow discharge' to 0 or 1 if it is False/True or Null in _user_swmm_nodes_ table.
- [x] Set _swmm_allow_discharge_ in _user_swmm_nodes_ to 0 or 1 when reading SWMM.INP.
- [x] Move message to message bar when saving inlets.
![imagen](https://github.com/FLO-2DSoftware/qgis-flo-2d-plugin/assets/20424575/ff4d6b82-51d0-4077-b3f4-fa5deb6c1fcb)
- [x] Remove substring from messages after saving inlets, outfalls, conduits, pumps, orifices, and weirs.
![imagen](https://github.com/FLO-2DSoftware/qgis-flo-2d-plugin/assets/20424575/573bfa0c-bd5e-41a7-87f7-694541e79cd4)

