### PR TITLE
Add tooltips to FLO-2D Widget Buttons

### DIFF
--- a/flo2d/ui/f2d_widget.ui
+++ b/flo2d/ui/f2d_widget.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>371</width>
-        <height>662</height>
+        <width>363</width>
+        <height>740</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
@@ -158,6 +158,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="show_flo2d_table_btn">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;FLO-2D Table Editor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>...</string>
            </property>
@@ -169,6 +172,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="show_flo2d_plot_btn">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;FLO-2D Plots&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>...</string>
            </property>
@@ -180,6 +186,9 @@
          </item>
          <item>
           <widget class="QToolButton" name="clear_rubberband_btn">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clear tables and rubber band&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>...</string>
            </property>


### PR DESCRIPTION
Add tooltips to FLO-2D Widget Buttons
1. FLO-2D Table Editor
2. FLO-2D Plots
3. Clear tables and rubber band