### PR TITLE
Tooltips6

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -523,7 +523,7 @@ class Flo2D(object):
         # )
 
         self.add_action(
-            os.path.join(self.plugin_dir, "img/gri]d_info_tool.svg"),
+            os.path.join(self.plugin_dir, "img/grid_info_tool.svg"),
             text=self.tr("FLO-2D Grid Info Tool"),
             callback=lambda: self.activate_grid_info_tool(),
             parent=self.iface.mainWindow(),
@@ -2969,10 +2969,15 @@ class Flo2D(object):
                     dlg_components.hdf5_rb.setChecked(True)
                     dlg_components.data_rb.setChecked(False)
 
-            # enable “remove files” checkbox if any of these exist
-            files = ["FPLAIN.DAT", "CADPTS.DAT", "NEIGHBORS.DAT"]
+            # Check the presence of fplain cadpts neighbors dat files
+            files = [
+                "FPLAIN.DAT",
+                "CADPTS.DAT",
+                "NEIGHBORS.DAT"
+            ]
             for file in files:
-                if os.path.exists(os.path.join(outdir, file)):
+                file_path = os.path.join(outdir, file)
+                if os.path.exists(file_path):
                     dlg_components.remove_files_chbox.setEnabled(True)
                     break
 
@@ -2992,6 +2997,7 @@ class Flo2D(object):
                 if dlg_components.data_rb.isChecked():
                     export_type = "data"
                     s.setValue("FLO-2D/quickRun", "data")
+
             QApplication.setOverrideCursor(Qt.WaitCursor)
 
             if export_type == "data":

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -3060,24 +3060,105 @@ class Flo2D(object):
                                 os.remove(outdir + r"\MULT.DAT")
                             QApplication.restoreOverrideCursor()
 
-                if export_type == "hdf5":
-                    output_hdf5 = os.path.join(outdir, "Input.hdf5")
-                    if is_file_locked(output_hdf5):
-                        QApplication.restoreOverrideCursor()
-                        self.uc.bar_error("The file Input.hdf5 is currently open or locked by another process!")
-                        self.uc.log_info("The file Input.hdf5 is currently open or locked by another process!")
-                        return
-                    export_message = "Datasets exported to\n" + output_hdf5 + "\n\n"
+            # --- DATA vs HDF5 should be sibling branches ---
+            if export_type == "data":
+
+                if dlg_components.remove_files_chbox.isChecked():
+                    for file in files:
+                        p = os.path.join(outdir, file)
+                        if os.path.exists(p):
+                            os.remove(p)
+
+                export_message = "Files exported to\n" + outdir + "\n\n"
+                self.f2g = Flo2dGeoPackage(self.con, self.iface)
+
+                # Guard .remove() calls (avoid ValueError if not present)
+                if self.gutils.is_table_empty("raincell_data") and "export_raincell" in export_calls:
+                    export_calls.remove("export_raincell")
+                if self.gutils.is_table_empty("raincellraw") and "export_raincellraw" in export_calls:
+                    export_calls.remove("export_raincellraw")
+
+                self.export_flo2d_files(outdir, export_calls, dlg_components, overrides)
+
+                # Tailings post-fixup for files_used
+                if "export_tailings" in export_calls:
+                    MUD = self.gutils.get_cont_par("MUD")
+                    concentration_sql = """
+                        SELECT CASE WHEN COUNT(*) > 0 THEN True ELSE False END AS result
+                        FROM tailing_cells
+                        WHERE concentration <> 0 OR concentration IS NULL;
+                    """
+                    cv = self.gutils.execute(concentration_sql).fetchone()[0]
+                    if MUD == "1":
+                        if cv == 1:
+                            self.files_used = self.files_used.replace("TAILINGS.DAT\n", "TAILINGS_CV.DAT\n")
+                    elif MUD == "2":
+                        self.files_used = self.files_used.replace("TAILINGS.DAT\n", "TAILINGS_STACK_DEPTH.DAT\n")
+
+                # Delete stale .DATs if no data exists
+                if "export_mult" in export_calls:
+                    if self.gutils.is_table_empty("simple_mult_cells"):
+                        self.files_used = self.files_used.replace("SIMPLE_MULT.DAT\n", "")
+                        sm_path = os.path.join(outdir, "SIMPLE_MULT.DAT")
+                        if os.path.isfile(sm_path):
+                            # Temporarily drop the wait cursor while asking the user
+                            QApplication.restoreOverrideCursor()
+                            if self.uc.question(
+                                    "There are no simple multiple channel cells in the project but\n"
+                                    "there is a SIMPLE_MULT.DAT file in the directory.\n"
+                                    "If the file is not deleted it will be used by the model.\n\n"
+                                    "Delete SIMPLE_MULT.DAT?"
+                            ):
+                                os.remove(sm_path)
+                            QApplication.setOverrideCursor(Qt.WaitCursor)
+
+                    if self.gutils.is_table_empty("mult_cells"):
+                        # safer replace (previous string assumed \nMULT.DAT\n)
+                        self.files_used = self.files_used.replace("MULT.DAT\n", "")
+                        mult_path = os.path.join(outdir, "MULT.DAT")
+                        if os.path.isfile(mult_path):
+                            QApplication.restoreOverrideCursor()
+                            if self.uc.question(
+                                    "There are no multiple channel cells in the project but\n"
+                                    "there is a MULT.DAT file in the directory.\n"
+                                    "If the file is not deleted it will be used by the model.\n\n"
+                                    "Delete MULT.DAT?"
+                            ):
+                                os.remove(mult_path)
+                            QApplication.setOverrideCursor(Qt.WaitCursor)
+
+            elif export_type == "hdf5":
+                output_hdf5 = os.path.join(outdir, "Input.hdf5")
+
+                # Check lock before heavy work
+                if is_file_locked(output_hdf5):
+                    QApplication.restoreOverrideCursor()
+                    self.uc.bar_error("The file Input.hdf5 is currently open or locked by another process!")
+                    self.uc.log_info("The file Input.hdf5 is currently open or locked by another process!")
+                    return
+
+                export_message = "Datasets exported to\n" + output_hdf5 + "\n\n"
+
+                # Heavy work: set Wait cursor and guarantee restore
+                QApplication.setOverrideCursor(Qt.WaitCursor)
+                try:
                     self.f2g = Flo2dGeoPackage(self.con, self.iface, parsed_format=Flo2dGeoPackage.FORMAT_HDF5)
                     self.f2g.set_parser(output_hdf5, get_cell_size=False)
-                    remove = ("export_bridge_coeff_data", "export_wstime", "export_wsurf")
-                    export_calls_filtered = [item for item in export_calls if item not in remove]
+
+                    # Not used by HDF5
+                    remove = {"export_bridge_coeff_data", "export_wstime", "export_wsurf"}
+                    export_calls_filtered = [c for c in export_calls if c not in remove]
+
                     self.export_flo2d_files(output_hdf5, export_calls_filtered, dlg_components, overrides)
+                finally:
+                    QApplication.restoreOverrideCursor()
 
             else:
                 return
 
-            if self.files_used != "":
+            # Common post-export UI
+            if self.files_used:
+                # Ensure we’re not showing the dialog under a wait cursor
                 QApplication.restoreOverrideCursor()
                 info = export_message + self.files_used
                 self.uc.show_info(info)
@@ -3086,6 +3167,7 @@ class Flo2D(object):
             self.uc.bar_info("FLO-2D model exported to " + outdir, dur=3)
             self.uc.log_info("FLO-2D model exported to " + outdir)
 
+            # Final safety restore (harmless if already restored)
             QApplication.restoreOverrideCursor()
 
             if quick_run:

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -669,7 +669,7 @@ class ComponentsDialog(qtBaseClass, uiDialog):
             self.components.append("Tailings")
 
         if self.outrc_chbox.isChecked():
-            self.components.append("OUTrc")
+            self.components.append("Surface Water Rating Tables")
 
         self.accept() # Accept to return both `self.components` and `self.export_overrides` to the caller.
 

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -327,12 +327,14 @@ class ComponentsDialog(qtBaseClass, uiDialog):
                                    default_when_no_switch=True)
             self._pre_check_decision(self.gutters_chbox, has("gutter_cells"), None, default_when_no_switch=True)
             self._pre_check_decision(self.floodplain_xs_chbox, has("fpxsec"), None, default_when_no_switch=True)
-            self._pre_check_decision(self.spatial_shallow_n_chbox, has("spatialshallow") and has("spatialshallow_cells"),
+
+            self._pre_check_decision(self.spatial_shallow_n_chbox, has("spatialshallow_cells"),
                                    None, default_when_no_switch=True)
-            self._pre_check_decision(self.spatial_tolerance_chbox, has("tolspatial"), None, default_when_no_switch=True)
-            self._pre_check_decision(self.spatial_froude_chbox, has("fpfroude"), None, default_when_no_switch=True)
+            self._pre_check_decision(self.spatial_tolerance_chbox, has("tolspatial_cells"), None, default_when_no_switch=True)
+            self._pre_check_decision(self.spatial_froude_chbox, has("fpfroude_cells"), None, default_when_no_switch=True)
             self._pre_check_decision(self.spatial_steep_slopen_chbox, has("steep_slope_n_cells"), None,
                                    default_when_no_switch=True)
+
             self._pre_check_decision(self.spatial_lid_volume_chbox, has("lid_volume_cells"), None,
                                    default_when_no_switch=True)
             self._pre_check_decision(self.mannings_n_and_Topo_chbox, has("grid"), None, default_when_no_switch=True)

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -364,6 +364,7 @@ class ComponentsDialog(qtBaseClass, uiDialog):
                     self._pre_check_decision(self.multiple_channels_chbox, False, False)
                 else:
                     if self.gutils.is_table_empty("mult"):
+                        # There are mult or simple channels but 'mult' (globals) is empty: set globals:
                         self.gutils.fill_empty_mult_globals()
                     self._pre_check_decision(self.multiple_channels_chbox, True, True)
             else:
@@ -663,7 +664,7 @@ class ComponentsDialog(qtBaseClass, uiDialog):
             self.components.append("LID Volume")
 
         if self.mannings_n_and_Topo_chbox.isChecked():
-            self.components.append("Manning's n and Topography")
+            self.components.append("Manning's n and Topo")
 
         if self.tailings_chbox.isChecked():
             self.components.append("Tailings")

--- a/flo2d/gui/dlg_cont_toler_jj.py
+++ b/flo2d/gui/dlg_cont_toler_jj.py
@@ -486,21 +486,33 @@ class ContToler_JJ(qtBaseClass, uiDialog):
 
 
     def _guard_switch(self, checkbox, ok_predicate, warn_msg: str):
+        """
+        If user tries to check 'checkbox' but 'ok_predicate()' is False,
+        show a warning and revert the check.
+        """
+        # Prevent enabling a switch if required data is missing.
+        # Warn the user and immediately reset the checkbox to unchecked.
         if checkbox.isChecked() and not ok_predicate():
             self.uc.bar_warn(warn_msg)
             self.uc.log_info(warn_msg)
             checkbox.setChecked(False)
 
     def _has(self, table_name: str) -> bool:
+        # Return True if the given database table exists and is not empty.
         return not self.gutils.is_table_empty(table_name)
 
     def _any(self, *tables: str) -> bool:
+        # Return True if at least one of the given tables is non-empty.
         return any(self._has(t) for t in tables)
 
     def _all(self, *tables: str) -> bool:
+        # Return True only if all of the given tables are non-empty.
         return all(self._has(t) for t in tables)
 
     def _wire_switch_guards(self):
+        # Map each checkbox (model switch) to its validation condition and warning message.
+        # If the user enables a switch but the required dataset(s) are missing,
+        # the action is blocked and a warning is displayed.
         mapping = [
             (self.ICHANNEL, lambda: self._has("chan"),
              "No channels data configured!"),
@@ -533,6 +545,8 @@ class ContToler_JJ(qtBaseClass, uiDialog):
              "No storm drain data configured!"),
         ]
 
+        # Attach guard logic to each checkbox's click signal.
+        # Uses default arguments in the lambda to bind the right checkbox, predicate, and message.
         for cb, pred, msg in mapping:
             if cb is not None:  # in case some switches are not present in this dialog
                 cb.clicked.connect(lambda _=None, c=cb, p=pred, m=msg: self._guard_switch(c, p, m))

--- a/flo2d/gui/dlg_export_multidomain.py
+++ b/flo2d/gui/dlg_export_multidomain.py
@@ -300,7 +300,7 @@ class ExportMultipleDomainsDialog(qtBaseClass, uiDialog):
                 # if "Evaporation" not in dlg_components.components:
                 #     export_calls.remove("export_evapor")
 
-                if "Hydraulic  Structures" not in dlg_components.components:
+                if "Hydraulic Structures" not in dlg_components.components:
                     export_calls.remove("export_hystruc")
                     export_calls.remove("export_bridge_xsec")
                     if "export_bridge_coeff_data" in export_calls:


### PR DESCRIPTION
The following files were affected: dlg_components.py, dlg_cont_toler_jj.py, dlg_export_multidomain.py, and flo2d.py.
dlg_export_multidomain.py:
    Removed double space in "Hydraulic  Structure" to "Hydraulic Structure".
dlg_cont_toler_jj.py:
    Ensured a switch can only be checked if it's already configured. If not, it raises a warning and unchecks it.
dlg_components.py:
    1. Ensured components with data in CONT but not switched ON are only enabled but not pre-checked.
    2. For components in case 1, if then checked, a user is prompted to decide whether to only export but keep OFF the switch or  switch ON the switch and export.
flo2d.py:
    Ensure the decision in dlg_components.py (2) is respected (the component is kept at 0 or turned to 1 in CONT.DAT).