### PR TITLE
Update SCS Curve Number Warning Message

### DIFF
--- a/flo2d/gui/infil_editor_widget.py
+++ b/flo2d/gui/infil_editor_widget.py
@@ -624,7 +624,8 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
         except Exception as e:
             self.uc.log_info(traceback.format_exc())
             self.uc.show_warn(
-                "WARNING 060319.1724: Calculating SCS Curve Number parameters failed! Please check that the Raster covers the Grid Layer."
+                "WARNING 060319.1724: Calculating SCS Curve Number parameters failed! \n"
+                "Please check that the Raster covers the Grid Layer and the coordinate system is valid."
             )
         finally:
             QApplication.restoreOverrideCursor()


### PR DESCRIPTION
Let the user check that the Raster covers the Grid Layer and the coordinate system is valid.