### PR TITLE
Use project default default cell size to create grid

### DIFF
--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -166,6 +166,7 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                 cs = int(self.gutils.get_cont_par("CELLSIZE")) # Get cell size from cont table convert to integer
                 units = "m" if self.gutils.get_cont_par("METRIC") == "1" else "ft" # Get project units
                 self.uc.bar_warn(f"Defaulted to cell size of {cs} {units} from Project Settings")
+                self.uc.log_info(f"Defaulted to cell size of {cs} {units} from Project Settings")
             except (TypeError, ValueError):
                 cs = None
         if cs:


### PR DESCRIPTION
Use project default cell size from cont table to create grid when no cell size value is provided by the user.