### PR TITLE
Fix spinning cursor

### DIFF
--- a/flo2d/gui/struct_editor_widget.py
+++ b/flo2d/gui/struct_editor_widget.py
@@ -331,6 +331,9 @@ class StructEditorWidget(qtBaseClass, uiDialog):
                 # Set Structures on the Control Parameters
                 self.gutils.set_cont_par("IHYDRSTRUCT", 1)
 
+                while QApplication.overrideCursor():
+                    QApplication.restoreOverrideCursor()
+
                 # Return False there are some errors
                 if self.check_structures():
                     self.uc.bar_info("Schematizing Hydraulic Structures finished with errors. Check the report!")


### PR DESCRIPTION
Add and override cursor to stop the busy-cursor mode after schematizing structures when two/more structures share the same inlet/outlet