### PR TITLE
Fixed "Elevation Corrector Dialogs #2080"

### DIFF
--- a/flo2d/flo2d_tools/elevation_correctors.py
+++ b/flo2d/flo2d_tools/elevation_correctors.py
@@ -361,7 +361,7 @@ class GridElevation(ElevationCorrector):
             )
             ms_box.exec()
             ms_box.show()
-            return
+            return False
 
         if self.only_selected is True:
             request = self.request
@@ -400,6 +400,8 @@ class GridElevation(ElevationCorrector):
         cur.executemany(qry, qry_values)
         self.gutils.con.commit()
         self.remove_virtual_sum(self.user_points)
+
+        return True
 
     def tin_elevation_within_polygons(self):
 

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -745,9 +745,12 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                 method = correct_dlg.run_external
 
             QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
-            method()
+            result = method()
             QApplication.restoreOverrideCursor()
-            self.uc.show_info("Assigning grid elevation finished!")
+            if result:
+                self.uc.show_info("Assigning grid elevation finished!")
+            else:
+                self.uc.log_info("Elevation Polygon & Elevation points not defined.")
         except Exception as e:
             QApplication.restoreOverrideCursor()
             self.uc.log_info(traceback.format_exc())


### PR DESCRIPTION
Ensure the dialog "Assigning grid elevation finished!" does not come after the warning dialog "Please define Elevation Polygons & Points."