### PR TITLE
Open windows on qgis not second screen #1987 grid tools

### DIFF
--- a/flo2d/flo2d_ie/flo2dgeopackage.py
+++ b/flo2d/flo2d_ie/flo2dgeopackage.py
@@ -14655,6 +14655,8 @@ class Flo2dGeoPackage(GeoPackageUtils):
                     row[0] = int(row[0])
                     row[4] = int(row[4])
                     for value in row:
+                        if value in [None, "None"]:
+                            value = -9999
                         levee_group.datasets["BREACH_GLOBAL"].data.append([value])
 
             if local_rows:

--- a/flo2d/flo2d_tools/elevation_correctors.py
+++ b/flo2d/flo2d_tools/elevation_correctors.py
@@ -7,6 +7,7 @@ import functools
 import time
 from collections import defaultdict
 
+from qgis.utils import iface
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis._core import QgsMessageLog, QgsSpatialIndex
 from qgis.analysis import QgsZonalStatistics
@@ -308,7 +309,9 @@ class GridElevation(ElevationCorrector):
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Elevation Polygon."
+                "Please, define Elevation Polygon.",
+                QMessageBox.Ok,
+                iface.mainWindow()
             )
             ms_box.exec()
             ms_box.show()
@@ -357,7 +360,9 @@ class GridElevation(ElevationCorrector):
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Elevation Polygon & Elevation points."
+                "Please, define Elevation Polygon & Elevation points.",
+                QMessageBox.Ok,
+                iface.mainWindow()
             )
             ms_box.exec()
             ms_box.show()
@@ -409,7 +414,9 @@ class GridElevation(ElevationCorrector):
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Elevation Polygon."
+                "Please, define Elevation Polygon.",
+                QMessageBox.Ok,
+                iface.mainWindow()
             )
             ms_box.exec()
             ms_box.show()
@@ -473,7 +480,9 @@ class GridElevation(ElevationCorrector):
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Blocked Areas."
+                "Please, define Blocked Areas.",
+                QMessageBox.Ok,
+                iface.mainWindow()
             )
             ms_box.exec()
             ms_box.show()

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1267,6 +1267,8 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
                 QApplication.processEvents()
                 if prog.wasCanceled():
                     prog.close()
+                    QApplication.processEvents()
+                    prog.deleteLater()
                     return
 
             pnt = QgsGeometry.fromPointXY(QgsPointXY(x, y_tmp))
@@ -1318,6 +1320,7 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
             QApplication.processEvents()
             if prog.wasCanceled():
                 prog.close()
+                QApplication.processEvents()
                 prog.deleteLater()
                 return
 
@@ -1363,6 +1366,7 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
         prog.setValue(100)
 
     prog.close()
+    QApplication.processEvents()
     prog.deleteLater()
 
 

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1929,8 +1929,11 @@ def calculate_arfwrf(grid, areas):
         )
 
     finally:
-        pd.close()
-        pd.deleteLater()
+        try:
+            pd.close()
+            pd.deleteLater()
+        except:
+            pass
 
 def evaluate_spatial_tolerance(gutils, grid, areas):
     """

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1928,6 +1928,9 @@ def calculate_arfwrf(grid, areas):
             "_______________________________________________________________________________"
         )
 
+    finally:
+        pd.close()
+        pd.deleteLater()
 
 def evaluate_spatial_tolerance(gutils, grid, areas):
     """

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1871,61 +1871,56 @@ def calculate_arfwrf(grid, areas):
 
         features = grid.getFeatures()
 
-        try:
-            for feat in features:
-                geom = feat.geometry()
-                fids = index.intersects(geom.boundingBox())
+        for feat in features:
+            geom = feat.geometry()
+            fids = index.intersects(geom.boundingBox())
 
-                for fid in fids:
-                    f = allfeatures[fid]
-                    fgeom = f.geometry()
-                    if f["calc_arf"] == NULL or f["calc_wrf"] == NULL:
-                        was_null = True
-                    farf = int(round(1 if f["calc_arf"] == NULL else f["calc_arf"]))
-                    fwrf = int(round(1 if f["calc_wrf"] == NULL else f["calc_wrf"]))
-                    fcol = int(round(0 if f["collapse"] == NULL else f["collapse"]))
-                    inter = fgeom.intersects(geom)
-                    if inter is True:
-                        areas_intersection = fgeom.intersection(geom)
-                        arf = round(areas_intersection.area() / grid_area, 2) if farf == 1 else 0
-                        centroid = geom.centroid()
-                        centroid_wkt = centroid.asWkt()
-                        # Totally Blocked
-                        if arf >= 0.9:
-                            if fcol == 1:
-                                yield (centroid_wkt, -feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
-                            else:
-                                yield (centroid_wkt, feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
-                            continue
-                        # elif arf < 0.1:
-                        #     yield (centroid_wkt, feat.id(), f.id(), 0) + (full_wrf if fwrf == 1 else empty_wrf), was_null
-                        #     continue
-                        elif arf == 0:
-                            continue
-                        else:
-                            pass
-                        grid_center = centroid.asPoint()
-                        wrf_s = (f(grid_center.x(), grid_center.y(), half_square, half_octagon) for f in sides)
-                        wrf_geoms = (
-                            QgsGeometry.fromPolylineXY([QgsPointXY(x1, y1), QgsPointXY(x2, y2)]) for x1, y1, x2, y2 in wrf_s
-                        )
-                        if fwrf == 1:
-                            wrf = (round(line.intersection(fgeom).length() / octagon_side, 2) for line in wrf_geoms)
-                        else:
-                            wrf = empty_wrf
-                        # Partially Blocked
+            for fid in fids:
+                f = allfeatures[fid]
+                fgeom = f.geometry()
+                if f["calc_arf"] == NULL or f["calc_wrf"] == NULL:
+                    was_null = True
+                farf = int(round(1 if f["calc_arf"] == NULL else f["calc_arf"]))
+                fwrf = int(round(1 if f["calc_wrf"] == NULL else f["calc_wrf"]))
+                fcol = int(round(0 if f["collapse"] == NULL else f["collapse"]))
+                inter = fgeom.intersects(geom)
+                if inter is True:
+                    areas_intersection = fgeom.intersection(geom)
+                    arf = round(areas_intersection.area() / grid_area, 2) if farf == 1 else 0
+                    centroid = geom.centroid()
+                    centroid_wkt = centroid.asWkt()
+                    # Totally Blocked
+                    if arf >= 0.9:
                         if fcol == 1:
-                            yield (centroid_wkt, feat.id(), f.id(), -arf) + tuple(wrf), was_null
+                            yield (centroid_wkt, -feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
                         else:
-                            yield (centroid_wkt, feat.id(), f.id(), arf) + tuple(wrf), was_null
+                            yield (centroid_wkt, feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
+                        continue
+                    # elif arf < 0.1:
+                    #     yield (centroid_wkt, feat.id(), f.id(), 0) + (full_wrf if fwrf == 1 else empty_wrf), was_null
+                    #     continue
+                    elif arf == 0:
+                        continue
                     else:
                         pass
-                i += 1
-                pd.setValue(i)
-
-        finally:
-            pd.close()
-            pd.deleteLater()
+                    grid_center = centroid.asPoint()
+                    wrf_s = (f(grid_center.x(), grid_center.y(), half_square, half_octagon) for f in sides)
+                    wrf_geoms = (
+                        QgsGeometry.fromPolylineXY([QgsPointXY(x1, y1), QgsPointXY(x2, y2)]) for x1, y1, x2, y2 in wrf_s
+                    )
+                    if fwrf == 1:
+                        wrf = (round(line.intersection(fgeom).length() / octagon_side, 2) for line in wrf_geoms)
+                    else:
+                        wrf = empty_wrf
+                    # Partially Blocked
+                    if fcol == 1:
+                        yield (centroid_wkt, feat.id(), f.id(), -arf) + tuple(wrf), was_null
+                    else:
+                        yield (centroid_wkt, feat.id(), f.id(), arf) + tuple(wrf), was_null
+                else:
+                    pass
+            i += 1
+            pd.setValue(i)
 
     except:
         show_error(

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1854,7 +1854,7 @@ def calculate_arfwrf(grid, areas):
         full_wrf = (1,) * 8
         features.rewind()
 
-        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features))
+        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features), iface.mainWindow())
         pd.setModal(True)
         pd.setValue(0)
         pd.forceShow()
@@ -1862,56 +1862,61 @@ def calculate_arfwrf(grid, areas):
 
         features = grid.getFeatures()
 
-        for feat in features:
-            geom = feat.geometry()
-            fids = index.intersects(geom.boundingBox())
+        try:
+            for feat in features:
+                geom = feat.geometry()
+                fids = index.intersects(geom.boundingBox())
 
-            for fid in fids:
-                f = allfeatures[fid]
-                fgeom = f.geometry()
-                if f["calc_arf"] == NULL or f["calc_wrf"] == NULL:
-                    was_null = True
-                farf = int(round(1 if f["calc_arf"] == NULL else f["calc_arf"]))
-                fwrf = int(round(1 if f["calc_wrf"] == NULL else f["calc_wrf"]))
-                fcol = int(round(0 if f["collapse"] == NULL else f["collapse"]))
-                inter = fgeom.intersects(geom)
-                if inter is True:
-                    areas_intersection = fgeom.intersection(geom)
-                    arf = round(areas_intersection.area() / grid_area, 2) if farf == 1 else 0
-                    centroid = geom.centroid()
-                    centroid_wkt = centroid.asWkt()
-                    # Totally Blocked
-                    if arf >= 0.9:
-                        if fcol == 1:
-                            yield (centroid_wkt, -feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
+                for fid in fids:
+                    f = allfeatures[fid]
+                    fgeom = f.geometry()
+                    if f["calc_arf"] == NULL or f["calc_wrf"] == NULL:
+                        was_null = True
+                    farf = int(round(1 if f["calc_arf"] == NULL else f["calc_arf"]))
+                    fwrf = int(round(1 if f["calc_wrf"] == NULL else f["calc_wrf"]))
+                    fcol = int(round(0 if f["collapse"] == NULL else f["collapse"]))
+                    inter = fgeom.intersects(geom)
+                    if inter is True:
+                        areas_intersection = fgeom.intersection(geom)
+                        arf = round(areas_intersection.area() / grid_area, 2) if farf == 1 else 0
+                        centroid = geom.centroid()
+                        centroid_wkt = centroid.asWkt()
+                        # Totally Blocked
+                        if arf >= 0.9:
+                            if fcol == 1:
+                                yield (centroid_wkt, -feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
+                            else:
+                                yield (centroid_wkt, feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
+                            continue
+                        # elif arf < 0.1:
+                        #     yield (centroid_wkt, feat.id(), f.id(), 0) + (full_wrf if fwrf == 1 else empty_wrf), was_null
+                        #     continue
+                        elif arf == 0:
+                            continue
                         else:
-                            yield (centroid_wkt, feat.id(), f.id(), 1) + (full_wrf if fwrf == 1 else empty_wrf), was_null
-                        continue
-                    # elif arf < 0.1:
-                    #     yield (centroid_wkt, feat.id(), f.id(), 0) + (full_wrf if fwrf == 1 else empty_wrf), was_null
-                    #     continue
-                    elif arf == 0:
-                        continue
+                            pass
+                        grid_center = centroid.asPoint()
+                        wrf_s = (f(grid_center.x(), grid_center.y(), half_square, half_octagon) for f in sides)
+                        wrf_geoms = (
+                            QgsGeometry.fromPolylineXY([QgsPointXY(x1, y1), QgsPointXY(x2, y2)]) for x1, y1, x2, y2 in wrf_s
+                        )
+                        if fwrf == 1:
+                            wrf = (round(line.intersection(fgeom).length() / octagon_side, 2) for line in wrf_geoms)
+                        else:
+                            wrf = empty_wrf
+                        # Partially Blocked
+                        if fcol == 1:
+                            yield (centroid_wkt, feat.id(), f.id(), -arf) + tuple(wrf), was_null
+                        else:
+                            yield (centroid_wkt, feat.id(), f.id(), arf) + tuple(wrf), was_null
                     else:
                         pass
-                    grid_center = centroid.asPoint()
-                    wrf_s = (f(grid_center.x(), grid_center.y(), half_square, half_octagon) for f in sides)
-                    wrf_geoms = (
-                        QgsGeometry.fromPolylineXY([QgsPointXY(x1, y1), QgsPointXY(x2, y2)]) for x1, y1, x2, y2 in wrf_s
-                    )
-                    if fwrf == 1:
-                        wrf = (round(line.intersection(fgeom).length() / octagon_side, 2) for line in wrf_geoms)
-                    else:
-                        wrf = empty_wrf
-                    # Partially Blocked
-                    if fcol == 1:
-                        yield (centroid_wkt, feat.id(), f.id(), -arf) + tuple(wrf), was_null
-                    else:
-                        yield (centroid_wkt, feat.id(), f.id(), arf) + tuple(wrf), was_null
-                else:
-                    pass
-            i += 1
-            pd.setValue(i)
+                i += 1
+                pd.setValue(i)
+
+        finally:
+            pd.close()
+            pd.deleteLater()
 
     except:
         show_error(

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -36,6 +36,7 @@ from qgis.core import (
     QgsSpatialIndex,
     QgsSymbol,
 )
+from qgis.utils import iface
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import QApplication, QMessageBox, QProgressDialog
@@ -800,7 +801,7 @@ def poly2grid(cell_size, grid, polygons, request, use_centroids, get_fid, get_gr
     allfeatures, index = spatial_centroids_index(grid) if use_centroids is True else spatial_index(grid)
     polygon_features = polygons.getFeatures() if request is None else polygons.getFeatures(request)
 
-    pd = QProgressDialog("Assigning values...", None, 0, polygons.featureCount())
+    pd = QProgressDialog("Assigning values...", None, 0, polygons.featureCount(), iface.mainWindow())
     pd.setModal(True)
     pd.setValue(0)
     pd.forceShow()
@@ -1500,7 +1501,7 @@ def gridRegionGenerator(gutils, grid, gridSpan=100, regionPadding=50, showProgre
     # regionPadding = 50 # amount, in ft probably, to pad region extents to prevent boundary effects
 
     if showProgress == True:
-        progDialog = QProgressDialog("Processing Progress (by area - timing will be uneven)", "Cancel", 0, 100)
+        progDialog = QProgressDialog("Processing Progress (by area - timing will be uneven)", "Cancel", 0, 100, iface.mainWindow())
         progDialog.setModal(True)
         progDialog.setValue(0)
         progDialog.show()

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1143,11 +1143,12 @@ def raster2grid(grid, out_raster, iface, request=None):
 
     features = grid.getFeatures() if request is None else grid.getFeatures(request)
 
-    # pd = QProgressDialog("Probing raster...", None, 0, grid.featureCount(), iface.mainWindow())
-    pd = QProgressDialog("Probing raster...", None, 0, grid.featureCount())
-    pd.setModal(True)
+    pd = QProgressDialog("Probing raster...", None, 0, grid.featureCount(), iface.mainWindow())
+    pd.setWindowTitle("FLO-2D")
+    pd.setWindowModality(Qt.WindowModal)
+    pd.setMinimumDuration(0)
     pd.setValue(0)
-    pd.forceShow()
+
     i = 0
 
     for feat in features:
@@ -1163,7 +1164,8 @@ def raster2grid(grid, out_raster, iface, request=None):
         i += 1
         pd.setValue(i)
 
-
+    pd.close()
+    pd.deleteLater()
 
 def rasters2centroids(vlayer, request, *raster_paths):
     """
@@ -1240,10 +1242,9 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
 
     prog = QProgressDialog("Creating grid (1/3)...", "Cancel", 0, 100, iface.mainWindow())
     prog.setWindowTitle("FLO-2D")
-    prog.setWindowModality(qt_window_modality("WindowModal"))
+    prog.setWindowModality(Qt.WindowModal)
     prog.setMinimumDuration(0)
     prog.setValue(0)
-    QApplication.processEvents()
 
     # Update UI about ~200 times max
     update_every = max(1, total_candidates // 200)
@@ -1313,6 +1314,7 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
             QApplication.processEvents()
             if prog.wasCanceled():
                 prog.close()
+                prog.deleteLater()
                 return
 
         n = row[0]
@@ -1356,6 +1358,7 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
 
     prog.setValue(100)
     prog.close()
+    prog.deleteLater()
 
 
 def square_grid_with_col_and_row_fields(gutils, boundary, upper_left_coords=None):

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1863,7 +1863,7 @@ def calculate_arfwrf(grid, areas):
         full_wrf = (1,) * 8
         features.rewind()
 
-        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features), iface.mainWindow())
+        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features))
         pd.setModal(True)
         pd.setValue(0)
         pd.forceShow()

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1928,12 +1928,6 @@ def calculate_arfwrf(grid, areas):
             "_______________________________________________________________________________"
         )
 
-    finally:
-        try:
-            pd.close()
-            pd.deleteLater()
-        except:
-            pass
 
 def evaluate_spatial_tolerance(gutils, grid, areas):
     """

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -834,6 +834,9 @@ def poly2grid(cell_size, grid, polygons, request, use_centroids, get_fid, get_gr
         i += 1
         pd.setValue(i)
 
+    pd.close()
+    pd.deleteLater()
+
 def poly2poly(base_polygons, polygons, request, area_percent, *columns):
     """
     Generator which calculates base polygons intersections with another polygon layer.
@@ -1357,7 +1360,8 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
         drop_temp_table_query = "DROP TABLE temp_table;"
         gutils.execute(drop_temp_table_query)
 
-    prog.setValue(100)
+        prog.setValue(100)
+
     prog.close()
     prog.deleteLater()
 
@@ -1531,6 +1535,7 @@ def gridRegionGenerator(gutils, grid, gridSpan=100, regionPadding=50, showProgre
                     break
         if showProgress == True:
             progDialog.close()
+            progDialog.deleteLater()
 
 
 def geos2geosGenerator(gutils, grid, inputFC, *valueColumnNames, extraFC=None):

--- a/flo2d/gui/dlg_create_grid.py
+++ b/flo2d/gui/dlg_create_grid.py
@@ -13,7 +13,7 @@ import os
 
 from qgis._core import QgsWkbTypes
 from qgis.core import QgsFieldProxyModel, QgsMapLayerProxyModel, NULL
-from qgis.PyQt.QtCore import QSettings
+from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtWidgets import QFileDialog
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QDesktopServices
@@ -31,7 +31,6 @@ class CreateGridDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowModality(qt_window_modality("WindowModal"))
         self.ok_btn = self.buttonBox.button(qdialogbuttonbox_button("Ok"))
         self.ok_btn.setEnabled(False)
         self.cellSizeSpinBox.valueChanged.connect(lambda v: self.ok_btn.setEnabled(v != 0))
@@ -207,7 +206,7 @@ class CreateGridDialog(qtBaseClass, uiDialog):
         s = QSettings()
         last_elev_raster_dir = s.value("FLO-2D/lastElevRasterDir", "")
         src_file, __ = QFileDialog.getOpenFileName(
-            None,
+            self,
             "Choose elevation raster...",
             directory=last_elev_raster_dir,
             filter="Elev (*.tif )",

--- a/flo2d/gui/dlg_sampling_point_elev.py
+++ b/flo2d/gui/dlg_sampling_point_elev.py
@@ -43,7 +43,6 @@ class SamplingPointElevDialog(qtBaseClass, uiDialog):
         self.grid = None
         self.cell_size = float(cell_size)
         self.setupUi(self)
-        self.setWindowModality(qt_window_modality("WindowModal"))
         self.gutils = GeoPackageUtils(con, iface)
         self.gpkg_path = self.gutils.get_gpkg_path()
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -425,7 +425,12 @@ class GridToolsWidget(qtBaseClass, uiDialog):
             return
         cell_size = self.get_cell_size()
         dlg = SamplingPointElevDialog(self.con, self.iface, self.lyrs, cell_size)
-        ok = dlg.exec()
+
+        try:
+            dlg.exec()
+        finally:
+            dlg.close()
+            dlg.deleteLater()
 
     def xyz_elevation(self):
         try:

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -165,12 +165,17 @@ class GridToolsWidget(qtBaseClass, uiDialog):
         create_grid_dlg = CreateGridDialog(self.iface, self.lyrs)
         ok = create_grid_dlg.exec()
         if not ok:
+            for w in QApplication.topLevelWidgets():
+                if isinstance(w, QProgressDialog):
+                    w.close()
+                    w.deletelater()
+            create_grid_dlg.deleteLater()
             return
 
         # get value from dialog spinbox
         dlg_cell_size = create_grid_dlg.cell_size()
 
-        # try:
+        # try
         if not self.lyrs.save_edits_and_proceed("Computational Domain"):
             return
         if create_grid_dlg.use_external_layer():
@@ -305,6 +310,10 @@ class GridToolsWidget(qtBaseClass, uiDialog):
         QApplication.restoreOverrideCursor()
         self.uc.log_info(grid_summary)
         self.uc.show_info(grid_summary)
+
+        create_grid_dlg.deleteLater()
+
+
 
         # else:
         #     # Update grid_lyr:

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -727,6 +727,7 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                 )
 
     def correct_elevation(self):
+        correct_dlg = None
         try:
             if self.gutils.is_table_empty("grid"):
                 self.uc.bar_warn("There is no grid! Please create it before running tool.")
@@ -773,6 +774,10 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                 + "\n___________________________________________________",
                 e,
             )
+        finally:
+            if correct_dlg is not None:
+                correct_dlg.close()
+                correct_dlg.deleteLater()
 
     def get_roughness(self):
         if not self.lyrs.save_edits_and_proceed("Roughness"):


### PR DESCRIPTION
ensure the grid tools dialog boxes are closed and deleted successfully to avoid ghost/stale preview when one hover over QGIS on the taskbar.