### PR TITLE
Open windows on qgis not second screen #1987 grid tools revised

### DIFF
--- a/flo2d/flo2d_tools/elevation_correctors.py
+++ b/flo2d/flo2d_tools/elevation_correctors.py
@@ -7,6 +7,7 @@ import functools
 import time
 from collections import defaultdict
 
+from qgis.utils import iface
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis._core import QgsMessageLog, QgsSpatialIndex
 from qgis.analysis import QgsZonalStatistics
@@ -305,10 +306,13 @@ class GridElevation(ElevationCorrector):
     def elevation_from_polygons(self):
 
         if self.user_polygons.featureCount() <= 0:
+            parent = iface.mainWindow() if iface and iface.mainWindow() else None
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Elevation Polygon."
+                "Please, define Elevation Polygon.",
+                QMessageBox.Ok,
+                parent
             )
             ms_box.exec()
             ms_box.show()
@@ -354,10 +358,13 @@ class GridElevation(ElevationCorrector):
     def elevation_from_tin(self):
 
         if self.user_polygons.featureCount() <= 0 or self.user_points.featureCount() <= 0:
+            parent = iface.mainWindow() if iface and iface.mainWindow() else None
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Elevation Polygon & Elevation points."
+                "Please, define Elevation Polygon & Elevation points.",
+                QMessageBox.Ok,
+                parent
             )
             ms_box.exec()
             ms_box.show()
@@ -404,12 +411,14 @@ class GridElevation(ElevationCorrector):
         return True
 
     def tin_elevation_within_polygons(self):
-
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
         if self.user_polygons.featureCount() <= 0:
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Elevation Polygon."
+                "Please, define Elevation Polygon.",
+                QMessageBox.Ok,
+                parent
             )
             ms_box.exec()
             ms_box.show()
@@ -468,12 +477,14 @@ class GridElevation(ElevationCorrector):
         self.gutils.con.commit()
 
     def elevation_within_arf(self, calculation_type):
-
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
         if self.blocked_areas.featureCount() <= 0:
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
-                "Please, define Blocked Areas."
+                "Please, define Blocked Areas.",
+                QMessageBox.Ok,
+                parent
             )
             ms_box.exec()
             ms_box.show()

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1153,10 +1153,9 @@ def raster2grid(grid, out_raster, iface, request=None):
     parent = iface.mainWindow() if iface and iface.mainWindow() else None
 
     pd = QProgressDialog("Probing raster...", None, 0, grid.featureCount(), parent)
-    pd.setWindowTitle("FLO-2D")
-    pd.setWindowModality(Qt.WindowModal)
-    pd.setMinimumDuration(0)
+    pd.setModal(True)
     pd.setValue(0)
+    pd.forceShow()
 
     i = 0
 
@@ -1251,10 +1250,9 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
     total_candidates = cols * rows
 
     prog = QProgressDialog("Creating grid (1/3)...", "Cancel", 0, 100, iface.mainWindow())
-    prog.setWindowTitle("FLO-2D")
-    prog.setWindowModality(Qt.WindowModal)
-    prog.setMinimumDuration(0)
+    prog.setModal(True)
     prog.setValue(0)
+    prog.forceShow()
 
     # Update UI about ~200 times max
     update_every = max(1, total_candidates // 200)
@@ -1517,12 +1515,10 @@ def gridRegionGenerator(gutils, grid, gridSpan=100, regionPadding=50, showProgre
 
         parent = iface.mainWindow() if iface and iface.mainWindow() else None
 
-        progDialog = QProgressDialog("Processing Progress (by area - timing will be uneven)", "Cancel", 0, 100,
-                                     parent)
+        progDialog = QProgressDialog("Processing Progress (by area - timing will be uneven)", "Cancel", 0, 100, parent)
         progDialog.setModal(True)
         progDialog.setValue(0)
-        progDialog.show()
-        QApplication.processEvents()
+        progDialog.forceShow()
 
     while regionCounter < regionCount:
         for row in range(rowCount):

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -801,7 +801,7 @@ def poly2grid(cell_size, grid, polygons, request, use_centroids, get_fid, get_gr
     allfeatures, index = spatial_centroids_index(grid) if use_centroids is True else spatial_index(grid)
     polygon_features = polygons.getFeatures() if request is None else polygons.getFeatures(request)
 
-    parent = iface.mainWindow() if iface.mainWindow() else None
+    parent = iface.mainWindow() if iface and iface.mainWindow() else None
 
     pd = QProgressDialog("Assigning values...", None, 0, polygons.featureCount(), parent)
     pd.setModal(True)

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -801,13 +801,15 @@ def poly2grid(cell_size, grid, polygons, request, use_centroids, get_fid, get_gr
     allfeatures, index = spatial_centroids_index(grid) if use_centroids is True else spatial_index(grid)
     polygon_features = polygons.getFeatures() if request is None else polygons.getFeatures(request)
 
-    pd = QProgressDialog("Assigning values...", None, 0, polygons.featureCount())
+    parent = iface.mainWindow() if iface.mainWindow() else None
+
+    pd = QProgressDialog("Assigning values...", None, 0, polygons.featureCount(), parent)
     pd.setModal(True)
     pd.setValue(0)
     pd.forceShow()
     i = 0
     QApplication.processEvents()
-    
+
     for feat in polygon_features:
         fid = feat.id()
         geom = feat.geometry()
@@ -833,6 +835,10 @@ def poly2grid(cell_size, grid, polygons, request, use_centroids, get_fid, get_gr
             yield values
         i += 1
         pd.setValue(i)
+
+    pd.close()
+    pd.deleteLater()
+
 
 def poly2poly(base_polygons, polygons, request, area_percent, *columns):
     """
@@ -1144,11 +1150,14 @@ def raster2grid(grid, out_raster, iface, request=None):
 
     features = grid.getFeatures() if request is None else grid.getFeatures(request)
 
-    # pd = QProgressDialog("Probing raster...", None, 0, grid.featureCount(), iface.mainWindow())
-    pd = QProgressDialog("Probing raster...", None, 0, grid.featureCount())
-    pd.setModal(True)
+    parent = iface.mainWindow() if iface and iface.mainWindow() else None
+
+    pd = QProgressDialog("Probing raster...", None, 0, grid.featureCount(), parent)
+    pd.setWindowTitle("FLO-2D")
+    pd.setWindowModality(Qt.WindowModal)
+    pd.setMinimumDuration(0)
     pd.setValue(0)
-    pd.forceShow()
+
     i = 0
 
     for feat in features:
@@ -1164,6 +1173,8 @@ def raster2grid(grid, out_raster, iface, request=None):
         i += 1
         pd.setValue(i)
 
+    pd.close()
+    pd.deleteLater()
 
 
 def rasters2centroids(vlayer, request, *raster_paths):
@@ -1241,10 +1252,9 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
 
     prog = QProgressDialog("Creating grid (1/3)...", "Cancel", 0, 100, iface.mainWindow())
     prog.setWindowTitle("FLO-2D")
-    prog.setWindowModality(qt_window_modality("WindowModal"))
+    prog.setWindowModality(Qt.WindowModal)
     prog.setMinimumDuration(0)
     prog.setValue(0)
-    QApplication.processEvents()
 
     # Update UI about ~200 times max
     update_every = max(1, total_candidates // 200)
@@ -1263,6 +1273,8 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
                 QApplication.processEvents()
                 if prog.wasCanceled():
                     prog.close()
+                    QApplication.processEvents()
+                    prog.deleteLater()
                     return
 
             pnt = QgsGeometry.fromPointXY(QgsPointXY(x, y_tmp))
@@ -1285,7 +1297,6 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
             y_tmp -= cellsize
         x += cellsize
     prog.setValue(100)
-
 
     # Reuse the SAME progress dialog, just change message
     prog.setLabelText("Writing grid elements (2/3)...")
@@ -1314,6 +1325,8 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
             QApplication.processEvents()
             if prog.wasCanceled():
                 prog.close()
+                QApplication.processEvents()
+                prog.deleteLater()
                 return
 
         n = row[0]
@@ -1355,8 +1368,11 @@ def square_grid(gutils, boundary, iface, upper_left_coords=None):
         drop_temp_table_query = "DROP TABLE temp_table;"
         gutils.execute(drop_temp_table_query)
 
-    prog.setValue(100)
+        prog.setValue(100)
+
     prog.close()
+    QApplication.processEvents()
+    prog.deleteLater()
 
 
 def square_grid_with_col_and_row_fields(gutils, boundary, upper_left_coords=None):
@@ -1498,7 +1514,11 @@ def gridRegionGenerator(gutils, grid, gridSpan=100, regionPadding=50, showProgre
     # regionPadding = 50 # amount, in ft probably, to pad region extents to prevent boundary effects
 
     if showProgress == True:
-        progDialog = QProgressDialog("Processing Progress (by area - timing will be uneven)", "Cancel", 0, 100)
+
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
+
+        progDialog = QProgressDialog("Processing Progress (by area - timing will be uneven)", "Cancel", 0, 100,
+                                     parent)
         progDialog.setModal(True)
         progDialog.setValue(0)
         progDialog.show()
@@ -1528,6 +1548,7 @@ def gridRegionGenerator(gutils, grid, gridSpan=100, regionPadding=50, showProgre
                     break
         if showProgress == True:
             progDialog.close()
+            progDialog.deleteLater()
 
 
 def geos2geosGenerator(gutils, grid, inputFC, *valueColumnNames, extraFC=None):

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1851,7 +1851,9 @@ def calculate_arfwrf(grid, areas):
         full_wrf = (1,) * 8
         features.rewind()
 
-        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features))
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
+
+        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features), parent)
         pd.setModal(True)
         pd.setValue(0)
         pd.forceShow()
@@ -1915,6 +1917,10 @@ def calculate_arfwrf(grid, areas):
             "ERROR 060319.1606: Evaluation of ARFs and WRFs failed! Please check your Blocked Areas User Layer.\n"
             "_______________________________________________________________________________"
         )
+
+    finally:
+        pd.close()
+        pd.deleteLater()
 
 
 def evaluate_spatial_tolerance(gutils, grid, areas):

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -1851,7 +1851,7 @@ def calculate_arfwrf(grid, areas):
         full_wrf = (1,) * 8
         features.rewind()
 
-        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features), iface.mainWindow())
+        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features))
         pd.setModal(True)
         pd.setValue(0)
         pd.forceShow()

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from operator import itemgetter
 from subprocess import PIPE, STDOUT, Popen
 
+from qgis.utils import iface
 import numpy as np
 from qgis.PyQt.QtCore import QMetaType
 from qgis._core import QgsField, QgsVectorDataProvider, QgsMessageLog
@@ -1850,7 +1851,7 @@ def calculate_arfwrf(grid, areas):
         full_wrf = (1,) * 8
         features.rewind()
 
-        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features))
+        pd = QProgressDialog("Calculating ARF and WRF...", None, 0, sum(1 for feature in features), iface.mainWindow())
         pd.setModal(True)
         pd.setValue(0)
         pd.forceShow()

--- a/flo2d/gui/dlg_create_grid.py
+++ b/flo2d/gui/dlg_create_grid.py
@@ -31,7 +31,6 @@ class CreateGridDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowModality(qt_window_modality("WindowModal"))
         self.ok_btn = self.buttonBox.button(qdialogbuttonbox_button("Ok"))
         self.ok_btn.setEnabled(False)
         self.cellSizeSpinBox.valueChanged.connect(lambda v: self.ok_btn.setEnabled(v != 0))
@@ -207,7 +206,7 @@ class CreateGridDialog(qtBaseClass, uiDialog):
         s = QSettings()
         last_elev_raster_dir = s.value("FLO-2D/lastElevRasterDir", "")
         src_file, __ = QFileDialog.getOpenFileName(
-            None,
+            self,
             "Choose elevation raster...",
             directory=last_elev_raster_dir,
             filter="Elev (*.tif )",

--- a/flo2d/gui/dlg_sampling_point_elev.py
+++ b/flo2d/gui/dlg_sampling_point_elev.py
@@ -43,7 +43,6 @@ class SamplingPointElevDialog(qtBaseClass, uiDialog):
         self.grid = None
         self.cell_size = float(cell_size)
         self.setupUi(self)
-        self.setWindowModality(qt_window_modality("WindowModal"))
         self.gutils = GeoPackageUtils(con, iface)
         self.gpkg_path = self.gutils.get_gpkg_path()
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -73,7 +73,6 @@ from .ui_utils import load_ui, set_icon
 
 from ..gui.dlg_rgh import RGHDialog
 
-
 uiDialog, qtBaseClass = load_ui("grid_tools_widget")
 
 
@@ -165,12 +164,17 @@ class GridToolsWidget(qtBaseClass, uiDialog):
         create_grid_dlg = CreateGridDialog(self.iface, self.lyrs)
         ok = create_grid_dlg.exec()
         if not ok:
+            for w in QApplication.topLevelWidgets():
+                if isinstance(w, QProgressDialog):
+                    w.close()
+                    w.deletelater()
+            create_grid_dlg.deleteLater()
             return
 
         # get value from dialog spinbox
         dlg_cell_size = create_grid_dlg.cell_size()
 
-        # try:
+        # try
         if not self.lyrs.save_edits_and_proceed("Computational Domain"):
             return
         if create_grid_dlg.use_external_layer():
@@ -306,6 +310,8 @@ class GridToolsWidget(qtBaseClass, uiDialog):
         self.uc.log_info(grid_summary)
         self.uc.show_info(grid_summary)
 
+        create_grid_dlg.deleteLater()
+
         # else:
         #     # Update grid_lyr:
         #     grid_lyr = self.lyrs.data["grid"]["qlyr"]
@@ -416,7 +422,12 @@ class GridToolsWidget(qtBaseClass, uiDialog):
             return
         cell_size = self.get_cell_size()
         dlg = SamplingPointElevDialog(self.con, self.iface, self.lyrs, cell_size)
-        ok = dlg.exec()
+
+        try:
+            dlg.exec()
+        finally:
+            dlg.close()
+            dlg.deleteLater()
 
     def xyz_elevation(self):
         try:
@@ -713,6 +724,7 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                 )
 
     def correct_elevation(self):
+        correct_dlg = None
         try:
             if self.gutils.is_table_empty("grid"):
                 self.uc.bar_warn("There is no grid! Please create it before running tool.")
@@ -759,6 +771,10 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                 + "\n___________________________________________________",
                 e,
             )
+        finally:
+            if correct_dlg is not None:
+                correct_dlg.close()
+                correct_dlg.deleteLater()
 
     def get_roughness(self):
         if not self.lyrs.save_edits_and_proceed("Roughness"):
@@ -1906,7 +1922,6 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                                           names='Time, Depth, Velocity, Water_Surface_Elevation')
 
         return data
-
 
     def eval_rgh(self):
         if self.gutils.is_table_empty("grid"):

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -756,15 +756,12 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                     return
                 method = correct_dlg.run_external
 
-            QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
             result = method()
-            QApplication.restoreOverrideCursor()
             if result:
                 self.uc.show_info("Assigning grid elevation finished!")
             else:
                 self.uc.log_info("Elevation Polygon & Elevation points not defined.")
         except Exception as e:
-            QApplication.restoreOverrideCursor()
             self.uc.log_info(traceback.format_exc())
             self.uc.show_error(
                 "ERROR 060319.1607: Assigning grid elevation aborted! Please check your input layers."


### PR DESCRIPTION
- Use iface.mainWindow() to ensure that dialogs are displayed only on top of the QGIS window and not any other active window/screen/app/monitor.
- Use .close() and .deleteLater() window management methods to ensure that no ghost/stale previews of dialogs appear when one hover over QGIS from the taskbar.