### PR TITLE
Grid tool correct grid elevation #2087

### DIFF
--- a/flo2d/flo2d_tools/elevation_correctors.py
+++ b/flo2d/flo2d_tools/elevation_correctors.py
@@ -39,6 +39,7 @@ from .grid_tools import (
 )
 from .schematic_tools import get_intervals, interpolate_along_line, polys2levees
 from ..utils import qmeta_type
+from .. user_communication import UserCommunication
 
 
 def timer(func):
@@ -288,6 +289,8 @@ class GridElevation(ElevationCorrector):
     def __init__(self, gutils, lyrs):
         super(GridElevation, self).__init__(gutils, lyrs)
 
+        self.uc = UserCommunication(iface, "FLO-2D")
+
         self.grid = None
         self.blocked_areas = None
 
@@ -316,7 +319,9 @@ class GridElevation(ElevationCorrector):
             )
             ms_box.exec()
             ms_box.show()
-            return
+
+            self.uc.log_info("Elevation polygon not defined.")
+            return False
 
         if self.only_selected is True:
             request = self.request
@@ -355,6 +360,8 @@ class GridElevation(ElevationCorrector):
 
         self.gutils.con.commit()
 
+        return True
+
     def elevation_from_tin(self):
 
         if self.user_polygons.featureCount() <= 0 or self.user_points.featureCount() <= 0:
@@ -368,6 +375,8 @@ class GridElevation(ElevationCorrector):
             )
             ms_box.exec()
             ms_box.show()
+
+            self.uc.log_info("Elevation Polygon & Elevation Points not defined.")
             return False
 
         if self.only_selected is True:
@@ -422,7 +431,9 @@ class GridElevation(ElevationCorrector):
             )
             ms_box.exec()
             ms_box.show()
-            return
+
+            self.uc.log_info("Elevation Polygon not defined.")
+            return False
 
         if self.only_selected is True:
             request = self.request
@@ -476,6 +487,8 @@ class GridElevation(ElevationCorrector):
         cur.executemany(qry, qry_values)
         self.gutils.con.commit()
 
+        return True
+
     def elevation_within_arf(self, calculation_type):
         parent = iface.mainWindow() if iface and iface.mainWindow() else None
         if self.blocked_areas.featureCount() <= 0:
@@ -488,7 +501,9 @@ class GridElevation(ElevationCorrector):
             )
             ms_box.exec()
             ms_box.show()
-            return
+
+            self.uc.log_info("Blocked Areas not defined.")
+            return False
 
         if calculation_type == "Mean":
 
@@ -529,6 +544,8 @@ class GridElevation(ElevationCorrector):
         cur = self.gutils.con.cursor()
         cur.executemany(qry, qry_values)
         self.gutils.con.commit()
+
+        return True
 
 
 class ExternalElevation(ElevationCorrector):

--- a/flo2d/flo2d_tools/elevation_correctors.py
+++ b/flo2d/flo2d_tools/elevation_correctors.py
@@ -8,7 +8,7 @@ import time
 from collections import defaultdict
 
 from qgis.utils import iface
-from qgis.PyQt.QtWidgets import QMessageBox
+from qgis.PyQt.QtWidgets import QMessageBox, QApplication
 from qgis._core import QgsMessageLog, QgsSpatialIndex
 from qgis.analysis import QgsZonalStatistics
 from qgis.core import (
@@ -309,6 +309,7 @@ class GridElevation(ElevationCorrector):
     def elevation_from_polygons(self):
 
         if self.user_polygons.featureCount() <= 0:
+            QApplication.restoreOverrideCursor()
             parent = iface.mainWindow() if iface and iface.mainWindow() else None
             ms_box = QMessageBox(
                 QMessageBox.Critical,
@@ -365,6 +366,7 @@ class GridElevation(ElevationCorrector):
     def elevation_from_tin(self):
 
         if self.user_polygons.featureCount() <= 0 or self.user_points.featureCount() <= 0:
+            QApplication.restoreOverrideCursor()
             parent = iface.mainWindow() if iface and iface.mainWindow() else None
             ms_box = QMessageBox(
                 QMessageBox.Critical,
@@ -422,6 +424,7 @@ class GridElevation(ElevationCorrector):
     def tin_elevation_within_polygons(self):
         parent = iface.mainWindow() if iface and iface.mainWindow() else None
         if self.user_polygons.featureCount() <= 0:
+            QApplication.restoreOverrideCursor()
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
@@ -492,6 +495,7 @@ class GridElevation(ElevationCorrector):
     def elevation_within_arf(self, calculation_type):
         parent = iface.mainWindow() if iface and iface.mainWindow() else None
         if self.blocked_areas.featureCount() <= 0:
+            QApplication.restoreOverrideCursor()
             ms_box = QMessageBox(
                 QMessageBox.Critical,
                 "Error",
@@ -501,7 +505,6 @@ class GridElevation(ElevationCorrector):
             )
             ms_box.exec()
             ms_box.show()
-
             self.uc.log_info("Blocked Areas not defined.")
             return False
 

--- a/flo2d/gui/dlg_grid_elev.py
+++ b/flo2d/gui/dlg_grid_elev.py
@@ -91,26 +91,26 @@ class GridCorrectionDialog(qtBaseClass, uiDialog):
     def tin_method(self):
         try:
             self.internal_corrector.set_filter()
-            self.internal_corrector.elevation_from_tin()
+            return self.internal_corrector.elevation_from_tin()
         finally:
             self.internal_corrector.clear_filter()
 
     def tin_poly_method(self):
         try:
             self.internal_corrector.set_filter()
-            self.internal_corrector.tin_elevation_within_polygons()
+            return self.internal_corrector.tin_elevation_within_polygons()
         finally:
             self.internal_corrector.clear_filter()
 
     def polygon_method(self):
         try:
             self.internal_corrector.set_filter()
-            self.internal_corrector.elevation_from_polygons()
+            return self.internal_corrector.elevation_from_polygons()
         finally:
             self.internal_corrector.clear_filter()
 
     def arf_method(self):
-        self.internal_corrector.elevation_within_arf(self.stats_cbx.currentText())
+        return self.internal_corrector.elevation_within_arf(self.stats_cbx.currentText())
 
     def populate_polygon_vectors(self):
         poly_lyrs = self.lyrs.list_group_vlayers()
@@ -208,7 +208,10 @@ class GridCorrectionDialog(qtBaseClass, uiDialog):
 
     def run_internal(self):
         for no in sorted(self.internal_methods):
-            self.internal_methods[no]()
+            result = self.internal_methods[no]()
+            if result is False:
+                return False
+        return True
 
     def run_external(self):
         self.external_method()

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -757,10 +757,13 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                 method = correct_dlg.run_external
 
             result = method()
-            if result:
-                self.uc.show_info("Assigning grid elevation finished!")
-            else:
-                self.uc.log_info("Elevation Polygon & Elevation points not defined.")
+
+            if not result:
+                return
+
+            self.uc.show_info("Assigning grid elevation finished!")
+            self.uc.log_info("Assigning grid elevation finished!")
+
         except Exception as e:
             self.uc.log_info(traceback.format_exc())
             self.uc.show_error(

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -756,7 +756,10 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                     return
                 method = correct_dlg.run_external
 
+            QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
+
             result = method()
+            QApplication.restoreOverrideCursor()
 
             if not result:
                 return
@@ -765,6 +768,7 @@ class GridToolsWidget(qtBaseClass, uiDialog):
             self.uc.log_info("Assigning grid elevation finished!")
 
         except Exception as e:
+            QApplication.restoreOverrideCursor()
             self.uc.log_info(traceback.format_exc())
             self.uc.show_error(
                 "ERROR 060319.1607: Assigning grid elevation aborted! Please check your input layers."


### PR DESCRIPTION
- Return result from the functions tin_method, tin_poly_method, polygon_method, arf_method, and run_internal to propagate  failure state.

- Add log messages after ms_boxs (errors) for each of the following functions: elevation_from_polygons, elevation_from_tin, tin_elevation_within_polygons, and elevation_within_arf.
add True, False flags to each of the above functions.

- Set and restore waitcursor when elevation polygons/points or blocked areas are defined/not defined.