### PR TITLE
Open-windows-on-QGIS-not-second-screen-#1987-Street_Editor

### DIFF
--- a/flo2d/gui/street_editor_widget.py
+++ b/flo2d/gui/street_editor_widget.py
@@ -18,6 +18,7 @@ from ..flo2d_tools.schematic_tools import schematize_streets
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
 from .ui_utils import center_canvas, load_ui, set_icon, switch_to_selected
+from ..utils import  qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("street_editor")
 uiDialog_pop, qtBaseClass_pop = load_ui("street_global")
@@ -30,7 +31,7 @@ class StreetGeneral(uiDialog_pop, qtBaseClass_pop):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
 
 
@@ -41,7 +42,6 @@ class StreetEditorWidget(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        # self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/street_editor_widget.py
+++ b/flo2d/gui/street_editor_widget.py
@@ -12,6 +12,7 @@ import traceback
 
 from qgis.core import QgsFeatureRequest
 from qgis.PyQt.QtWidgets import QInputDialog
+from qgis.PyQt.QtCore import Qt
 
 from ..flo2d_tools.schematic_tools import schematize_streets
 from ..geopackage_utils import GeoPackageUtils
@@ -24,11 +25,12 @@ uiDialog_pop, qtBaseClass_pop = load_ui("street_global")
 
 class StreetGeneral(uiDialog_pop, qtBaseClass_pop):
     def __init__(self, iface, lyrs):
-        qtBaseClass_pop.__init__(self)
+        qtBaseClass_pop.__init__(self, iface.mainWindow())
         uiDialog_pop.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
 
 
@@ -39,6 +41,7 @@ class StreetEditorWidget(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        # self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/street_editor_widget.py
+++ b/flo2d/gui/street_editor_widget.py
@@ -18,7 +18,7 @@ from ..flo2d_tools.schematic_tools import schematize_streets
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
 from .ui_utils import center_canvas, load_ui, set_icon, switch_to_selected
-from ..utils import  qt_window_flag
+from ..utils import qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("street_editor")
 uiDialog_pop, qtBaseClass_pop = load_ui("street_global")


### PR DESCRIPTION
- Ensure the dialog "Global streets parameters" and "Change street name" is parented to QGIS and that its ghost/stale preview does not appear later when QGIS is hovered over from the taskbar.
- Replace:
    self.setWindowFlags(Qt.Dialog | Qt.Tool)
with:
    self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
