### PR TITLE
Open windows on qgis not second screen #1987 editor widgets plus toolbar

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -90,7 +90,7 @@ from .layers import Layers
 from .misc.invisible_lyrs_grps import InvisibleLayersAndGroups
 from .user_communication import UserCommunication, is_file_locked
 from .utils import get_flo2dpro_version, get_plugin_version, qt_cursor_shape, qt_toolbutton_popup_mode, \
-    qt_dock_widget_area, dock_area_from_int, qt_window_type
+    qt_dock_widget_area, dock_area_from_int, qt_window_type, mb_icon
 
 from PIL import Image
 
@@ -2584,7 +2584,7 @@ class Flo2D(object):
         }
 
         if bname not in file_to_import_calls:
-            QMessageBox.critical(
+            mb_icon("Critical")(
                 self.iface.mainWindow(),
                 "Import selected DAT file",
                 "Import from {0} file is not supported.".format(bname),
@@ -2617,7 +2617,7 @@ class Flo2D(object):
 
             except Exception as e:
                 QApplication.restoreOverrideCursor()
-                QMessageBox.critical(
+                mb_icon("Critical")(
                     self.iface.mainWindow(),
                     "Import selected GDS file",
                     "Import from {0} fails".format(bname),

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -3211,7 +3211,7 @@ class Flo2D(object):
                     msg.addButton(QPushButton("Keep existing and complete"), self.uc.msgbox_role("YesRole"))
                     msg.addButton(QPushButton("Create new Storm Drains"), self.uc.msgbox_role("NoRole"))
                     msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
-                    msg.setDefaultButton(QMessageBox().Cancel)
+                    msg.setDefaultButton(self.uc.msgbox_button("Cancel"))
                     msg.setIcon(QMessageBox.Question)
                     ret = msg.exec()
                     QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -90,7 +90,7 @@ from .layers import Layers
 from .misc.invisible_lyrs_grps import InvisibleLayersAndGroups
 from .user_communication import UserCommunication, is_file_locked
 from .utils import get_flo2dpro_version, get_plugin_version, qt_cursor_shape, qt_toolbutton_popup_mode, \
-    qt_dock_widget_area, dock_area_from_int, qt_window_type
+    qt_dock_widget_area, dock_area_from_int, qt_window_type, mb_role, mb_button
 
 from PIL import Image
 
@@ -2617,7 +2617,7 @@ class Flo2D(object):
 
             except Exception as e:
                 QApplication.restoreOverrideCursor()
-                mb_icon("Critical")(
+                QMessageBox.critical(
                     self.iface.mainWindow(),
                     "Import selected GDS file",
                     "Import from {0} fails".format(bname),
@@ -3210,7 +3210,7 @@ class Flo2D(object):
 
                     msg.addButton(QPushButton("Keep existing and complete"), self.uc.msgbox_role("YesRole"))
                     msg.addButton(QPushButton("Create new Storm Drains"), self.uc.msgbox_role("NoRole"))
-                    msg.addButton(QPushButton("Cancel"), QMessageBox.RejectRole)
+                    msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
                     msg.setDefaultButton(QMessageBox().Cancel)
                     msg.setIcon(QMessageBox.Question)
                     ret = msg.exec()

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -4097,7 +4097,8 @@ class Flo2D(object):
                 #                     dletes = Qt.convertFromPlainText(dletes)
                 QApplication.restoreOverrideCursor()
 
-                m = QMessageBox()
+                parent = iface.mainWindow() if iface and iface.mainWindow() else None
+                m = QMessageBox(parent)
                 title = "Duplicate Opposite Levee Directions".center(170)
                 m.setWindowTitle(title)
                 m.setText(

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -38,7 +38,7 @@ from qgis.PyQt.QtWidgets import (
     QMenu,
     QMessageBox
 )
-from qgis.utils import plugins
+from qgis.utils import plugins, iface
 from .flo2d_ie.flo2dgeopackage import Flo2dGeoPackage
 from .flo2d_tools.flopro_tools import (
     ProgramExecutor,
@@ -1641,31 +1641,39 @@ class Flo2D(object):
     def call_IO_methods_hdf5(self, calls, debug, *args):
         self.f2g.parser.write_mode = "w"
 
-        progDialog = QProgressDialog("Exporting to HDF5...", None, 0, len(calls))
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
+        progDialog = QProgressDialog("Exporting to HDF5...", None, 0, len(calls), parent)
         progDialog.setModal(True)
         progDialog.setValue(0)
         progDialog.show()
-        i = 0
 
-        for call in calls:
+        try:
 
-            i += 1
-            progDialog.setValue(i)
-            progDialog.setLabelText(call)
-            QApplication.processEvents()
+            i = 0
 
-            method = getattr(self.f2g, call)
-            try:
-                method(*args)
-                self.f2g.parser.write_mode = "a"
-            except Exception as e:
-                if debug is True:
-                    self.uc.log_info(traceback.format_exc())
-                else:
-                    raise
+            for call in calls:
 
-        self.f2g.parser.write_mode = "w"
-        self.files_used = self.f2g.parser.list_input_subfolders()
+                i += 1
+                progDialog.setValue(i)
+                progDialog.setLabelText(call)
+                QApplication.processEvents()
+
+                method = getattr(self.f2g, call)
+                try:
+                    method(*args)
+                    self.f2g.parser.write_mode = "a"
+                except Exception as e:
+                    if debug is True:
+                        self.uc.log_info(traceback.format_exc())
+                    else:
+                        raise
+
+            self.f2g.parser.write_mode = "w"
+            self.files_used = self.f2g.parser.list_input_subfolders()
+
+        finally:
+            progDialog.close()
+            progDialog.deleteLater()
 
     def call_IO_methods_dat(self, calls, debug, *args):
         s = QSettings()
@@ -1676,7 +1684,8 @@ class Flo2D(object):
         if calls[0] == "export_cont_toler":
             self.files_used = "CONT.DAT\n"
 
-        progDialog = QProgressDialog("Exporting to DATA...", None, 0, len(calls))
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
+        progDialog = QProgressDialog("Exporting to DATA...", None, 0, len(calls), parent)
         progDialog.setModal(True)
         progDialog.setValue(0)
         progDialog.show()
@@ -1776,6 +1785,8 @@ class Flo2D(object):
                 else:
                     raise
 
+        progDialog.close()
+        progDialog.deleteLater()
         QApplication.restoreOverrideCursor()
 
     @connection_required
@@ -2256,11 +2267,12 @@ class Flo2D(object):
         Import selected traditional GDS files into FLO-2D database (GeoPackage).
         """
         self.uncheck_all_info_tools()
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
         msg = "This import method imports .DAT files without importing grid related files.\n\n" \
               "* Select 'Several Components' to import multiple *.DAT files.\n" \
               "* Select 'One Single Component' to import one single *.DAT file.\n"
         imprt = self.uc.dialog_with_2_customized_buttons(
-            "Select import method", msg, " Several Components", " One Single Component"
+            "Select import method", msg, " Several Components", " One Single Component", parent
         )
 
         if imprt == self.uc.msgbox_button("Yes"):
@@ -3187,7 +3199,8 @@ class Flo2D(object):
             if self.f2g.set_parser(fname, get_cell_size=False):
                 if not empty_sd:
                     QApplication.restoreOverrideCursor()
-                    msg = QMessageBox()
+                    parent = iface.mainWindow() if iface and iface.mainWindow() else None
+                    msg = QMessageBox(parent)
                     msg.setWindowTitle("Replace or complete Storm Drain User Data")
                     msg.setText(
                         "There is already Storm Drain data in the Users Layers.\n\nWould you like to keep it and "

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -90,7 +90,7 @@ from .layers import Layers
 from .misc.invisible_lyrs_grps import InvisibleLayersAndGroups
 from .user_communication import UserCommunication, is_file_locked
 from .utils import get_flo2dpro_version, get_plugin_version, qt_cursor_shape, qt_toolbutton_popup_mode, \
-    qt_dock_widget_area, dock_area_from_int, qt_window_type, mb_icon
+    qt_dock_widget_area, dock_area_from_int, qt_window_type
 
 from PIL import Image
 
@@ -2584,7 +2584,7 @@ class Flo2D(object):
         }
 
         if bname not in file_to_import_calls:
-            mb_icon("Critical")(
+            QMessageBox.critical(
                 self.iface.mainWindow(),
                 "Import selected DAT file",
                 "Import from {0} file is not supported.".format(bname),

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -3212,7 +3212,7 @@ class Flo2D(object):
                     msg.addButton(QPushButton("Create new Storm Drains"), self.uc.msgbox_role("NoRole"))
                     msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
                     msg.setDefaultButton(self.uc.msgbox_button("Cancel"))
-                    msg.setIcon(QMessageBox.Question)
+                    msg.setIcon(self.uc.msgbox_icon("Question"))
                     ret = msg.exec()
                     QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
                     if ret == 0:

--- a/flo2d/flo2d_tools/elevation_correctors.py
+++ b/flo2d/flo2d_tools/elevation_correctors.py
@@ -38,7 +38,7 @@ from .grid_tools import (
     spatial_index,
 )
 from .schematic_tools import get_intervals, interpolate_along_line, polys2levees
-from ..utils import qmeta_type
+from ..utils import qmeta_type, mb_icon, mb_button
 from .. user_communication import UserCommunication
 
 
@@ -312,10 +312,10 @@ class GridElevation(ElevationCorrector):
             QApplication.restoreOverrideCursor()
             parent = iface.mainWindow() if iface and iface.mainWindow() else None
             ms_box = QMessageBox(
-                QMessageBox.Critical,
+                mb_icon("Critical"),
                 "Error",
                 "Please, define Elevation Polygon.",
-                QMessageBox.Ok,
+                mb_button("Ok"),
                 parent
             )
             ms_box.exec()
@@ -369,10 +369,10 @@ class GridElevation(ElevationCorrector):
             QApplication.restoreOverrideCursor()
             parent = iface.mainWindow() if iface and iface.mainWindow() else None
             ms_box = QMessageBox(
-                QMessageBox.Critical,
+                mb_icon("Critical"),
                 "Error",
                 "Please, define Elevation Polygon & Elevation points.",
-                QMessageBox.Ok,
+                mb_button("Ok"),
                 parent
             )
             ms_box.exec()
@@ -426,10 +426,10 @@ class GridElevation(ElevationCorrector):
         if self.user_polygons.featureCount() <= 0:
             QApplication.restoreOverrideCursor()
             ms_box = QMessageBox(
-                QMessageBox.Critical,
+                mb_icon("Critical"),
                 "Error",
                 "Please, define Elevation Polygon.",
-                QMessageBox.Ok,
+                mb_button("Ok"),
                 parent
             )
             ms_box.exec()
@@ -497,10 +497,10 @@ class GridElevation(ElevationCorrector):
         if self.blocked_areas.featureCount() <= 0:
             QApplication.restoreOverrideCursor()
             ms_box = QMessageBox(
-                QMessageBox.Critical,
+                mb_icon("Critical"),
                 "Error",
                 "Please, define Blocked Areas.",
-                QMessageBox.Ok,
+                mb_button("Ok"),
                 parent
             )
             ms_box.exec()

--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -44,7 +44,7 @@ from qgis.PyQt.QtWidgets import QApplication, QMessageBox, QProgressDialog
 
 from ..errors import Flo2dError, GeometryValidityErrors
 from ..gui.ui_utils import center_canvas, zoom_show_n_cells
-from ..utils import get_file_path, is_number, qt_cursor_shape, qt_window_modality, qt_pen_style, qmeta_type
+from ..utils import get_file_path, is_number, qt_cursor_shape, qt_window_modality, qt_pen_style, qmeta_type, mb_icon
 
 cellIDNumpyArray = None
 xvalsNumpyArray = None
@@ -446,7 +446,7 @@ def show_error(msg):
     function = exc_tb.tb_frame.f_code.co_name
     line = str(exc_tb.tb_lineno)
     ms_box = QMessageBox(
-        QMessageBox.Critical,
+        mb_icon("Critical"),
         "Error",
         msg
         + "\n\n"

--- a/flo2d/gui/dlg_arf_wrf.py
+++ b/flo2d/gui/dlg_arf_wrf.py
@@ -11,6 +11,7 @@ from qgis._core import QgsWkbTypes
 from qgis.core import QgsFieldProxyModel, QgsMapLayerProxyModel
 from qgis.PyQt.QtCore import Qt
 
+from ..utils import qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("evaluate_blocked_areas")
@@ -22,7 +23,7 @@ class EvaluateReductionFactorsDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.collapse_cbo.setFilters(QgsFieldProxyModel.Numeric | QgsFieldProxyModel.String)
         self.arf_cbo.setFilters(QgsFieldProxyModel.Numeric | QgsFieldProxyModel.String)
         self.wrf_cbo.setFilters(QgsFieldProxyModel.Numeric | QgsFieldProxyModel.String)

--- a/flo2d/gui/dlg_breach.py
+++ b/flo2d/gui/dlg_breach.py
@@ -719,11 +719,12 @@ uiDialog_individual_levees, qtBaseClass = load_ui("individual_levee_data")
 
 class IndividualLeveesDialog(qtBaseClass, uiDialog_individual_levees):
     def __init__(self, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog_individual_levees.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_breach.py
+++ b/flo2d/gui/dlg_breach.py
@@ -19,7 +19,6 @@ from qgis.PyQt.QtGui import (
 )
 from qgis.PyQt.QtWidgets import (
     QApplication,
-    QInputDialog,
     QTableWidgetItem,
     QWidget,
 )
@@ -34,7 +33,7 @@ from ..flo2d_tools.grid_tools import (
 )
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
-from ..utils import float_or_zero, int_or_zero, qt_item_role, qt_cursor_shape, qevent_type
+from ..utils import float_or_zero, int_or_zero, qt_item_role, qt_cursor_shape, qevent_type, qt_window_flag
 from .ui_utils import center_canvas, load_ui, set_icon, zoom, zoom_cell_buffer
 
 
@@ -158,7 +157,7 @@ class GlobalBreachDialog(qtBaseClass, uiDialog_global):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -366,7 +365,7 @@ class IndividualBreachDialog(qtBaseClass, uiDialog_individual_breach):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -590,7 +589,7 @@ class LeveeFragilityCurvesDialog(qtBaseClass, uiDialog_levee_fragility):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -723,7 +722,7 @@ class IndividualLeveesDialog(qtBaseClass, uiDialog_individual_levees):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_breach.py
+++ b/flo2d/gui/dlg_breach.py
@@ -153,11 +153,12 @@ uiDialog_global, qtBaseClass = load_ui("global_breach_data")
 
 class GlobalBreachDialog(qtBaseClass, uiDialog_global):
     def __init__(self, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog_global.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -360,11 +361,12 @@ uiDialog_individual_breach, qtBaseClass = load_ui("individual_breach_data")
 
 class IndividualBreachDialog(qtBaseClass, uiDialog_individual_breach):
     def __init__(self, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog_individual_breach.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -583,11 +585,12 @@ uiDialog_levee_fragility, qtBaseClass = load_ui("levee_fragility_curves")
 
 class LeveeFragilityCurvesDialog(qtBaseClass, uiDialog_levee_fragility):
     def __init__(self, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog_levee_fragility.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_breach.py
+++ b/flo2d/gui/dlg_breach.py
@@ -157,7 +157,7 @@ class GlobalBreachDialog(qtBaseClass, uiDialog_global):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -365,7 +365,7 @@ class IndividualBreachDialog(qtBaseClass, uiDialog_individual_breach):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -589,7 +589,7 @@ class LeveeFragilityCurvesDialog(qtBaseClass, uiDialog_levee_fragility):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -722,7 +722,7 @@ class IndividualLeveesDialog(qtBaseClass, uiDialog_individual_levees):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_breach_hydrograph_tool.py
+++ b/flo2d/gui/dlg_breach_hydrograph_tool.py
@@ -25,17 +25,18 @@ import numpy as np
 
 import xml.etree.ElementTree as ET
 
-from ..utils import qt_window_type, qsizepolicy_policy
+from ..utils import qt_window_type, qsizepolicy_policy, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("breach_hydrograph_tool")
 
 
 class BreachHydrographToolDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs, bc_editor):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.bc_editor = bc_editor

--- a/flo2d/gui/dlg_channel_geometry.py
+++ b/flo2d/gui/dlg_channel_geometry.py
@@ -29,7 +29,7 @@ class ChannelGeometryDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_channel_geometry.py
+++ b/flo2d/gui/dlg_channel_geometry.py
@@ -24,11 +24,12 @@ uiDialog, qtBaseClass = load_ui("channel_geometry")
 
 class ChannelGeometryDialog(qtBaseClass, uiDialog):
     def __init__(self, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_channel_geometry.py
+++ b/flo2d/gui/dlg_channel_geometry.py
@@ -16,7 +16,7 @@ from ..flo2d_tools.grid_tools import (
 )
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
-from ..utils import float_or_zero, qt_item_role
+from ..utils import float_or_zero, qt_item_role, qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("channel_geometry")
@@ -29,7 +29,7 @@ class ChannelGeometryDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_channel_geometry.py
+++ b/flo2d/gui/dlg_channel_geometry.py
@@ -341,7 +341,7 @@ class ChannelGeometryDialog(qtBaseClass, uiDialog):
 
         idx = self.channel_segment_cbo.currentIndex() + 1
 
-        if self.initial_flow_elements_grp.isChecked():
+        if self.initial_flow_elems_grp.isChecked():
             self.initial_flow_for_all_dbox.setEnabled(False)
 
             exists = self.gutils.execute(sql_exists, (idx,)).fetchone()

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -29,7 +29,7 @@ class ComponentsDialog(qtBaseClass, uiDialog):
 
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -17,6 +17,7 @@ from ..flo2d_ie.flo2d_parser import ParseDAT
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
 from .ui_utils import load_ui
+from ..utils import qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("components")
 
@@ -28,7 +29,7 @@ class ComponentsDialog(qtBaseClass, uiDialog):
 
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -23,11 +23,12 @@ uiDialog, qtBaseClass = load_ui("components")
 
 class ComponentsDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs, in_or_out):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
 
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_cont_toler.py
+++ b/flo2d/gui/dlg_cont_toler.py
@@ -346,7 +346,7 @@ class ContToler(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.uc = UserCommunication(iface, "FLO-2D")
 

--- a/flo2d/gui/dlg_cont_toler.py
+++ b/flo2d/gui/dlg_cont_toler.py
@@ -17,7 +17,7 @@ from .dlg_mud_and_sediment import MudAndSedimentDialog
 from .rain_editor_widget import RainEditorWidget
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
-from ..utils import float_or_zero, qt_cursor_shape
+from ..utils import float_or_zero, qt_cursor_shape,qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("cont_toler")
@@ -346,7 +346,7 @@ class ContToler(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.gutils = GeoPackageUtils(con, iface)
         self.uc = UserCommunication(iface, "FLO-2D")
 

--- a/flo2d/gui/dlg_cont_toler.py
+++ b/flo2d/gui/dlg_cont_toler.py
@@ -340,12 +340,13 @@ class ContToler(qtBaseClass, uiDialog):
     )
 
     def __init__(self, con, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.con = con
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.gutils = GeoPackageUtils(con, iface)
         self.uc = UserCommunication(iface, "FLO-2D")
 

--- a/flo2d/gui/dlg_evap_editor.py
+++ b/flo2d/gui/dlg_evap_editor.py
@@ -14,7 +14,7 @@ from ..flo2dobjects import Evaporation
 from ..geopackage_utils import GeoPackageUtils
 from .plot_widget import PlotWidget
 from .ui_utils import load_ui
-from ..utils import qt_item_role
+from ..utils import qt_item_role, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("evaporation_editor")
 
@@ -37,12 +37,13 @@ month_names = [
 
 class EvapEditorDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.con = con
         self.setupUi(self)
         self.setup_plot()
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.setModal(False)
         self.evap = None
         self.gutils = GeoPackageUtils(con, iface)

--- a/flo2d/gui/dlg_export_multidomain.py
+++ b/flo2d/gui/dlg_export_multidomain.py
@@ -28,10 +28,11 @@ class ExportMultipleDomainsDialog(qtBaseClass, uiDialog):
         """
         Initialize the ExportMultipleDomainsDialog with required dependencies.
         """
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_export_multidomain.py
+++ b/flo2d/gui/dlg_export_multidomain.py
@@ -14,7 +14,7 @@ from .ui_utils import load_ui
 from ..flo2d_ie.flo2dgeopackage import Flo2dGeoPackage
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication, is_file_locked
-from ..utils import qt_cursor_shape
+from ..utils import qt_cursor_shape, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("export_multiple_domains")
 
@@ -32,7 +32,7 @@ class ExportMultipleDomainsDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_export_multidomain.py
+++ b/flo2d/gui/dlg_export_multidomain.py
@@ -32,7 +32,7 @@ class ExportMultipleDomainsDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_flopro.py
+++ b/flo2d/gui/dlg_flopro.py
@@ -10,7 +10,7 @@
 
 import os
 
-from qgis.PyQt.QtCore import QSettings
+from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtWidgets import QApplication, QFileDialog
 
 from ..flo2d_tools.flopro_tools import FLOPROExecutor
@@ -22,9 +22,10 @@ uiDialog, qtBaseClass = load_ui("flopro")
 
 class ExternalProgramFLO2D(qtBaseClass, uiDialog):
     def __init__(self, iface, title):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.iface = iface
         self.uc = UserCommunication(iface, "FLO-2D")
         self.flo2d_browse.clicked.connect(self.get_flo2d_dir)

--- a/flo2d/gui/dlg_flopro.py
+++ b/flo2d/gui/dlg_flopro.py
@@ -26,7 +26,7 @@ class ExternalProgramFLO2D(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.iface = iface
         self.uc = UserCommunication(iface, "FLO-2D")
         self.flo2d_browse.clicked.connect(self.get_flo2d_dir)

--- a/flo2d/gui/dlg_flopro.py
+++ b/flo2d/gui/dlg_flopro.py
@@ -16,6 +16,7 @@ from qgis.PyQt.QtWidgets import QApplication, QFileDialog
 from ..flo2d_tools.flopro_tools import FLOPROExecutor
 from ..user_communication import UserCommunication
 from .ui_utils import load_ui
+from ..utils import qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("flopro")
 
@@ -25,7 +26,7 @@ class ExternalProgramFLO2D(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.iface = iface
         self.uc = UserCommunication(iface, "FLO-2D")
         self.flo2d_browse.clicked.connect(self.get_flo2d_dir)

--- a/flo2d/gui/dlg_gpkg_backup.py
+++ b/flo2d/gui/dlg_gpkg_backup.py
@@ -8,7 +8,7 @@ from qgis._core import QgsProject
 
 from flo2d.gui.ui_utils import load_ui
 from flo2d.user_communication import UserCommunication
-from flo2d.utils import qt_cursor_shape
+from flo2d.utils import qt_cursor_shape, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("gpkg_backup")
 
@@ -18,7 +18,7 @@ class GpkgBackupDialog(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.iface = iface
         self.gutils = gutils
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_gpkg_backup.py
+++ b/flo2d/gui/dlg_gpkg_backup.py
@@ -18,7 +18,7 @@ class GpkgBackupDialog(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.iface = iface
         self.gutils = gutils
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_gpkg_backup.py
+++ b/flo2d/gui/dlg_gpkg_backup.py
@@ -15,9 +15,10 @@ uiDialog, qtBaseClass = load_ui("gpkg_backup")
 
 class GpkgBackupDialog(qtBaseClass, uiDialog):
     def __init__(self, iface, gutils):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.iface = iface
         self.gutils = gutils
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_gpkg_management.py
+++ b/flo2d/gui/dlg_gpkg_management.py
@@ -24,9 +24,10 @@ uiDialog, qtBaseClass = load_ui("gpkg_management")
 
 class GpkgManagementDialog(qtBaseClass, uiDialog):
     def __init__(self, iface, lyrs, gutils):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.iface = iface
         self.lyrs = lyrs
         self.gutils = gutils

--- a/flo2d/gui/dlg_gpkg_management.py
+++ b/flo2d/gui/dlg_gpkg_management.py
@@ -17,7 +17,7 @@ from flo2d.user_communication import UserCommunication
 
 import processing
 
-from flo2d.utils import qt_cursor_shape
+from flo2d.utils import qt_cursor_shape, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("gpkg_management")
 
@@ -27,7 +27,7 @@ class GpkgManagementDialog(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.iface = iface
         self.lyrs = lyrs
         self.gutils = gutils

--- a/flo2d/gui/dlg_gpkg_management.py
+++ b/flo2d/gui/dlg_gpkg_management.py
@@ -27,7 +27,7 @@ class GpkgManagementDialog(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.iface = iface
         self.lyrs = lyrs
         self.gutils = gutils

--- a/flo2d/gui/dlg_grid_elev.py
+++ b/flo2d/gui/dlg_grid_elev.py
@@ -13,6 +13,7 @@ from qgis.PyQt.QtCore import Qt
 
 from ..flo2d_tools.elevation_correctors import ExternalElevation, GridElevation
 from ..geopackage_utils import GeoPackageUtils
+from ..utils import qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("grid_elevation")
@@ -24,7 +25,7 @@ class GridCorrectionDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.gutils = GeoPackageUtils(con, iface)

--- a/flo2d/gui/dlg_hazus.py
+++ b/flo2d/gui/dlg_hazus.py
@@ -20,17 +20,18 @@ from ..gui.dlg_sampling_buildings_elevations import SamplingBuildingsElevationsD
 from ..gui.dlg_sampling_elev import SamplingElevDialog
 from ..user_communication import UserCommunication
 from .ui_utils import load_ui, set_icon
-from ..utils import qt_cursor_shape, qdialogbuttonbox_button
+from ..utils import qt_cursor_shape, qdialogbuttonbox_button, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("hazus")
 
 
 class HazusDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_import_multidomain.py
+++ b/flo2d/gui/dlg_import_multidomain.py
@@ -2,6 +2,7 @@ import math
 import os.path
 import time
 from itertools import combinations
+from qgis.utils import iface
 
 from ..deps import safe_h5py as h5py
 import numpy as np
@@ -39,7 +40,7 @@ class ImportMultipleDomainsDialog(qtBaseClass, uiDialog):
         """
 
         # Call parent class initializers
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
 
         # Initialize attributes
@@ -54,6 +55,8 @@ class ImportMultipleDomainsDialog(qtBaseClass, uiDialog):
 
         # Setup the UI
         self.setupUi(self)
+
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
 
         # Initialize subdomain dialog elements
         self.initialize_subdomain_elements()
@@ -441,7 +444,8 @@ class ImportMultipleDomainsDialog(qtBaseClass, uiDialog):
         """
         cell_size = None
 
-        progress_dialog = QProgressDialog(f"Importing Subdomain 1...", None, 1, total_subdomains + 1)
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
+        progress_dialog = QProgressDialog(f"Importing Subdomain 1...", None, 1, total_subdomains + 1, parent)
         progress_dialog.setWindowTitle("FLO-2D Multiple Domains Import")
         progress_dialog.setModal(True)
         progress_dialog.forceShow()
@@ -471,6 +475,7 @@ class ImportMultipleDomainsDialog(qtBaseClass, uiDialog):
                 progress_dialog.setValue(subdomain + 1)
 
         progress_dialog.close()
+        progress_dialog.deleteLater()
 
         # Get the min x and min y
         row = self.gutils.execute("""

--- a/flo2d/gui/dlg_import_multidomain.py
+++ b/flo2d/gui/dlg_import_multidomain.py
@@ -18,6 +18,7 @@ from ..flo2d_ie.flo2d_parser import ParseDAT
 from ..flo2d_ie.flo2dgeopackage import Flo2dGeoPackage
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
+from ..utils import qt_window_flag
 
 MAX_SUBDOMAINS = 15
 
@@ -56,7 +57,7 @@ class ImportMultipleDomainsDialog(qtBaseClass, uiDialog):
         # Setup the UI
         self.setupUi(self)
 
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
 
         # Initialize subdomain dialog elements
         self.initialize_subdomain_elements()

--- a/flo2d/gui/dlg_import_multidomain.py
+++ b/flo2d/gui/dlg_import_multidomain.py
@@ -57,7 +57,7 @@ class ImportMultipleDomainsDialog(qtBaseClass, uiDialog):
         # Setup the UI
         self.setupUi(self)
 
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
 
         # Initialize subdomain dialog elements
         self.initialize_subdomain_elements()

--- a/flo2d/gui/dlg_individual_multiple_channels.py
+++ b/flo2d/gui/dlg_individual_multiple_channels.py
@@ -12,7 +12,7 @@ from qgis.PyQt.QtCore import Qt
 
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
-from ..utils import float_or_zero, int_or_zero
+from ..utils import float_or_zero, int_or_zero, qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("individual_multiple_channels_data")
@@ -25,7 +25,7 @@ class IndividualMultipleChannelsDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -123,7 +123,7 @@ class IndividualSimplifiedMultipleChannelsDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_individual_multiple_channels.py
+++ b/flo2d/gui/dlg_individual_multiple_channels.py
@@ -8,6 +8,7 @@
 # of the License, or (at your option) any later version
 
 from qgis.PyQt.QtWidgets import QApplication
+from qgis.PyQt.QtCore import Qt
 
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
@@ -19,11 +20,12 @@ uiDialog, qtBaseClass = load_ui("individual_multiple_channels_data")
 
 class IndividualMultipleChannelsDialog(qtBaseClass, uiDialog):
     def __init__(self, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_individual_multiple_channels.py
+++ b/flo2d/gui/dlg_individual_multiple_channels.py
@@ -25,7 +25,7 @@ class IndividualMultipleChannelsDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -123,7 +123,7 @@ class IndividualSimplifiedMultipleChannelsDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_individual_multiple_channels.py
+++ b/flo2d/gui/dlg_individual_multiple_channels.py
@@ -118,11 +118,12 @@ uiDialog, qtBaseClass = load_ui("individual_simple_multiple_channels_data")
 
 class IndividualSimplifiedMultipleChannelsDialog(qtBaseClass, uiDialog):
     def __init__(self, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None

--- a/flo2d/gui/dlg_issues.py
+++ b/flo2d/gui/dlg_issues.py
@@ -9,6 +9,7 @@
 
 import os
 
+from qgis.utils import iface
 from qgis.PyQt.QtWidgets import QDockWidget
 from qgis.core import *
 from qgis.core import (
@@ -37,7 +38,7 @@ from ..flo2d_tools.grid_tools import (
 )
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
-from ..utils import copy_tablewidget_selection, qt_item_role, qt_cursor_shape, qt_dock_widget_area, qmeta_type
+from ..utils import copy_tablewidget_selection, qt_item_role, qt_cursor_shape, qt_dock_widget_area, qmeta_type, qt_window_flag
 from .ui_utils import center_canvas, load_ui, set_icon, zoom, zoom_show_n_cells
 
 # from qgis.core import QgsFeature, QgsGeometry, QgsPointXY
@@ -50,11 +51,12 @@ uiDialog, qtBaseClass = load_ui("errors_2")
 
 class ErrorsDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = None
         self.gutils = None
@@ -1286,10 +1288,11 @@ uiDialog, qtBaseClass = load_ui("issues_files")
 
 class IssuesFiles(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")
@@ -2805,30 +2808,34 @@ class LeveeCrestsDialog(qtBaseClass, uiDialog):
             cellsize = float(self.gutils.get_cont_par("CELLSIZE"))
 
             n_levees = len(levees)
-            pd = QProgressDialog("Finding levees...", None, 0, n_levees)
+            parent = iface.mainWindow() if iface and iface.mainWindow() else None
+            pd = QProgressDialog("Finding levees...", None, 0, n_levees, parent)
             pd.setWindowTitle("Warnings and Errors")
             pd.setModal(True)
             pd.forceShow()
             pd.setValue(0)
             i = 0
 
-            for i in range(n_levees):
-                cell = levees[i][0]
-                dir = levees[i][1]
-                crest = levees[i][2]
+            try:
+                for i in range(n_levees):
+                    cell = levees[i][0]
+                    dir = levees[i][1]
+                    crest = levees[i][2]
 
-                elev = self.gutils.grid_value(cell, "elevation")
+                    elev = self.gutils.grid_value(cell, "elevation")
 
-                adj_cell, adj_elev = get_adjacent_cell_elevation(self.gutils, grid_lyr, cell, dir, cellsize)
-                if adj_cell is not None and adj_elev != -999:
-                    if crest < elev or crest < adj_cell:
-                        self.levee_crests.append([str(i), cell, dir, crest, elev, adj_cell, adj_elev])
+                    adj_cell, adj_elev = get_adjacent_cell_elevation(self.gutils, grid_lyr, cell, dir, cellsize)
+                    if adj_cell is not None and adj_elev != -999:
+                        if crest < elev or crest < adj_cell:
+                            self.levee_crests.append([str(i), cell, dir, crest, elev, adj_cell, adj_elev])
 
-                i += 1
-                pd.setValue(i)
+                    i += 1
+                    pd.setValue(i)
+            finally:
+                pd.close()
+                pd.deleteLater()
 
         self.setWindowTitle("Levee Crests lower than cell elevations")
-
         self.create_levee_crests_conflicts_layer()
 
     def create_levee_crests_conflicts_layer(self):
@@ -2940,7 +2947,8 @@ class LeveeCrestsDialog(qtBaseClass, uiDialog):
         QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
         self.crest_tblw.setRowCount(0)
 
-        pd = QProgressDialog("Checking levees errors...", None, 0, len(self.levee_crests))
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
+        pd = QProgressDialog("Checking levees errors...", None, 0, len(self.levee_crests), parent)
         pd.setWindowTitle("Warnings and Errors")
         pd.setModal(True)
         pd.forceShow()
@@ -3006,6 +3014,8 @@ class LeveeCrestsDialog(qtBaseClass, uiDialog):
             i += 1
             pd.setValue(i)
 
+        pd.close()
+        pd.deleteLater()
         QApplication.restoreOverrideCursor()
 
     def elements_cbo_activated(self):

--- a/flo2d/gui/dlg_issues.py
+++ b/flo2d/gui/dlg_issues.py
@@ -400,6 +400,9 @@ class IssuesFromDEBUGDialog(qtBaseClass, uiDialog):
             # non-text dat:
             self.uc.show_warn(os.path.basename(debug_file) + " is not a text file!")
             self.uc.log_info(os.path.basename(debug_file) + " is not a text file!")
+
+            QApplication.restoreOverrideCursor()
+
             return False
 
     def populate_errors_cbo(self):

--- a/flo2d/gui/dlg_levee_elev.py
+++ b/flo2d/gui/dlg_levee_elev.py
@@ -19,17 +19,18 @@ from ..geopackage_utils import GeoPackageUtils
 from ..gui.dlg_walls_shapefile import WallsShapefile
 from ..user_communication import UserCommunication
 from .ui_utils import load_ui
-from ..utils import qdialogbuttonbox_button
+from ..utils import qdialogbuttonbox_button, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("levees_elevation")
 
 
 class LeveesToolDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_mud_and_sediment.py
+++ b/flo2d/gui/dlg_mud_and_sediment.py
@@ -12,13 +12,12 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import (
     QApplication,
     QComboBox,
-    QInputDialog,
     QTableWidgetItem,
 )
 
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
-from ..utils import FloatDelegate, qt_item_role, qt_cursor_shape
+from ..utils import FloatDelegate, qt_item_role, qt_cursor_shape, qt_window_flag
 from .ui_utils import load_ui, set_icon
 from ..flo2d_tools.grid_tools import number_of_elements
 
@@ -27,11 +26,12 @@ uiDialog, qtBaseClass = load_ui("mud_and_sediment")
 
 class MudAndSedimentDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = con
         self.gutils = None

--- a/flo2d/gui/dlg_multidomain_connectivity.py
+++ b/flo2d/gui/dlg_multidomain_connectivity.py
@@ -3,7 +3,7 @@ import time
 
 from ..deps import safe_h5py as h5py
 from qgis.PyQt.QtWidgets import QProgressDialog
-from qgis.PyQt.QtCore import NULL
+from qgis.PyQt.QtCore import NULL, Qt
 
 from .ui_utils import load_ui
 from ..geopackage_utils import GeoPackageUtils
@@ -14,10 +14,11 @@ uiDialog, qtBaseClass = load_ui("multiple_domains_connectivity")
 
 class MultipleDomainsConnectivityDialog(qtBaseClass, uiDialog):
     def __init__(self, iface, con, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_multidomain_connectivity.py
+++ b/flo2d/gui/dlg_multidomain_connectivity.py
@@ -8,6 +8,7 @@ from qgis.PyQt.QtCore import NULL, Qt
 from .ui_utils import load_ui
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
+from ..utils import qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("multiple_domains_connectivity")
 
@@ -18,7 +19,7 @@ class MultipleDomainsConnectivityDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_multidomain_connectivity.py
+++ b/flo2d/gui/dlg_multidomain_connectivity.py
@@ -19,7 +19,7 @@ class MultipleDomainsConnectivityDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_project_review_scenarios.py
+++ b/flo2d/gui/dlg_project_review_scenarios.py
@@ -23,16 +23,17 @@ from ..flo2d_ie.flo2d_parser import ParseDAT
 from ..user_communication import UserCommunication, is_file_locked
 import numpy as np
 
-from ..utils import qt_cursor_shape
+from ..utils import qt_cursor_shape, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("project_review_scenarios")
 
 
 class ProjectReviewScenariosDialog(qtBaseClass, uiDialog):
     def __init__(self, iface, gutils):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.iface = iface
         self.gutils = gutils
         self.parser = ParseDAT()

--- a/flo2d/gui/dlg_ras_import.py
+++ b/flo2d/gui/dlg_ras_import.py
@@ -26,7 +26,7 @@ class RasImportDialog(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.iface = iface
         self.lyrs = lyrs

--- a/flo2d/gui/dlg_ras_import.py
+++ b/flo2d/gui/dlg_ras_import.py
@@ -10,7 +10,7 @@
 
 import os
 
-from qgis.PyQt.QtCore import QSettings
+from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtWidgets import QFileDialog
 
 from ..flo2d_ie.ras_io import RASProject
@@ -22,9 +22,10 @@ uiDialog, qtBaseClass = load_ui("ras_import")
 
 class RasImportDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.con = con
         self.iface = iface
         self.lyrs = lyrs

--- a/flo2d/gui/dlg_ras_import.py
+++ b/flo2d/gui/dlg_ras_import.py
@@ -16,6 +16,7 @@ from qgis.PyQt.QtWidgets import QFileDialog
 from ..flo2d_ie.ras_io import RASProject
 from ..user_communication import UserCommunication
 from .ui_utils import load_ui
+from ..utils import qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("ras_import")
 
@@ -25,7 +26,7 @@ class RasImportDialog(qtBaseClass, uiDialog):
         qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.con = con
         self.iface = iface
         self.lyrs = lyrs

--- a/flo2d/gui/dlg_rgh.py
+++ b/flo2d/gui/dlg_rgh.py
@@ -13,6 +13,7 @@ import os
 from qgis.gui import QgsFileWidget
 from qgis.PyQt.QtCore import Qt
 
+from ..utils import qt_window_flag
 from .ui_utils import load_ui
 
 
@@ -30,7 +31,7 @@ class RGHDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
 
         # widgets from rgh.ui
         self.gb = self.mannings_n_rgh

--- a/flo2d/gui/dlg_sampling_elev.py
+++ b/flo2d/gui/dlg_sampling_elev.py
@@ -19,6 +19,7 @@ from qgis.PyQt.QtWidgets import QFileDialog
 from ..flo2d_tools.grid_tools import grid_has_empty_elev, raster2grid
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
+from ..utils import qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("sampling_elev")
@@ -44,7 +45,7 @@ class SamplingElevDialog(qtBaseClass, uiDialog):
         self.grid = None
         self.cell_size = float(cell_size)
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.gpkg_path = self.gutils.get_gpkg_path()
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_sampling_mann.py
+++ b/flo2d/gui/dlg_sampling_mann.py
@@ -13,6 +13,7 @@ from qgis.PyQt.QtCore import Qt
 
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
+from ..utils import qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("sampling_manning")
@@ -26,7 +27,7 @@ class SamplingManningDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.gpkg_path = self.gutils.get_gpkg_path()
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_sampling_raster_roughness.py
+++ b/flo2d/gui/dlg_sampling_raster_roughness.py
@@ -19,6 +19,7 @@ from qgis.PyQt.QtWidgets import QFileDialog
 from ..flo2d_tools.grid_tools import grid_has_empty_n_value, raster2grid
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
+from ..utils import qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("sampling_raster_roughness")
@@ -44,7 +45,7 @@ class SamplingRoughnessDialog(qtBaseClass, uiDialog):
         self.grid = None
         self.cell_size = float(cell_size)
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.gpkg_path = self.gutils.get_gpkg_path()
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_sampling_rc.py
+++ b/flo2d/gui/dlg_sampling_rc.py
@@ -122,7 +122,7 @@ class SamplingRCDialog(qtBaseClass, uiDialog):
         """
         uri = self.lyr_cbo.itemData(idx)
         lyr_id = self.lyrs.layer_exists_in_group(uri)
-        self.current_lyr = self.lyrs.gget_layer_by_id(lyr_id)
+        self.current_lyr = self.lyrs.get_layer_by_id(lyr_id)
 
         if isinstance(self.current_lyr, QgsVectorLayer):
             self.point_lyr_field_cbo.setHidden(False)

--- a/flo2d/gui/dlg_sampling_variable_into_grid.py
+++ b/flo2d/gui/dlg_sampling_variable_into_grid.py
@@ -15,7 +15,7 @@ from qgis.PyQt.QtCore import Qt
 from ..geopackage_utils import GeoPackageUtils
 from ..user_communication import UserCommunication
 from .ui_utils import load_ui
-from ..utils import qdialogbuttonbox_button
+from ..utils import qdialogbuttonbox_button, qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("sampling_variable_into_grid")
 
@@ -28,7 +28,7 @@ class SamplingOtherVariableDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = lyrs
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.gpkg_path = self.gutils.get_gpkg_path()
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_sampling_xyz.py
+++ b/flo2d/gui/dlg_sampling_xyz.py
@@ -38,7 +38,7 @@ from ..user_communication import UserCommunication
 from ..utils import (
     second_smallest,
     set_min_max_elevs,
-    time_taken, qt_cursor_shape, qmeta_type, qt_alignment_flag,
+    time_taken, qt_cursor_shape, qmeta_type, qt_alignment_flag, qt_window_flag
 )
 from .ui_utils import load_ui
 
@@ -58,7 +58,7 @@ class SamplingXYZDialog(qtBaseClass, uiDialog):
         self.grid = self.lyrs.data["grid"]["qlyr"]
 
         self.setupUi(self)
-        self.setWindowModality(Qt.WindowModal)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.gpkg_path = self.gutils.get_gpkg_path()
         self.uc = UserCommunication(iface, "FLO-2D")

--- a/flo2d/gui/dlg_schema2user.py
+++ b/flo2d/gui/dlg_schema2user.py
@@ -12,7 +12,7 @@ import traceback
 import os
 
 from qgis.PyQt.QtWidgets import QApplication
-from qgis.PyQt.QtCore import QSettings
+from qgis.PyQt.QtCore import QSettings, Qt
 
 from ..flo2d_tools.schema2user_tools import (
     Schema1DConverter,
@@ -32,10 +32,11 @@ uiDialog, qtBaseClass = load_ui("schema2user")
 
 class Schema2UserDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs, uc):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.con = con
         self.lyrs = lyrs
         self.uc = uc
@@ -92,7 +93,7 @@ class Schema2UserDialog(qtBaseClass, uiDialog):
         #     self.ckbox_swmm.setDisabled(True)
         # else:
         #     self.ckbox_swmm.setEnabled(True)
-            
+
         if any(self.gutils.is_table_empty(t) for t in schema_hydr_tables):
             self.ckbox_hydr_struct.setDisabled(True)
         else:

--- a/flo2d/gui/dlg_schema2user.py
+++ b/flo2d/gui/dlg_schema2user.py
@@ -26,6 +26,7 @@ from ..flo2d_tools.schema2user_tools import (
 from ..geopackage_utils import GeoPackageUtils
 from .ui_utils import load_ui
 from ..flo2d_ie.flo2d_parser import ParseDAT
+from ..utils import qt_window_flag
 
 uiDialog, qtBaseClass = load_ui("schema2user")
 

--- a/flo2d/gui/dlg_schema2user.py
+++ b/flo2d/gui/dlg_schema2user.py
@@ -36,7 +36,7 @@ class Schema2UserDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.con = con
         self.lyrs = lyrs
         self.uc = uc

--- a/flo2d/gui/dlg_schema2user.py
+++ b/flo2d/gui/dlg_schema2user.py
@@ -36,7 +36,7 @@ class Schema2UserDialog(qtBaseClass, uiDialog):
         uiDialog.__init__(self)
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.con = con
         self.lyrs = lyrs
         self.uc = uc

--- a/flo2d/gui/dlg_settings.py
+++ b/flo2d/gui/dlg_settings.py
@@ -45,11 +45,12 @@ uiDialog, qtBaseClass = load_ui("settings")
 
 class SettingsDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface, lyrs, gutils):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.ilg = InvisibleLayersAndGroups(self.iface)
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.setModal(True)
         self.con = con

--- a/flo2d/gui/dlg_settings.py
+++ b/flo2d/gui/dlg_settings.py
@@ -50,7 +50,7 @@ class SettingsDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.ilg = InvisibleLayersAndGroups(self.iface)
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.setModal(True)
         self.con = con

--- a/flo2d/gui/dlg_settings.py
+++ b/flo2d/gui/dlg_settings.py
@@ -37,7 +37,7 @@ from ..geopackage_utils import (
 )
 from ..misc.invisible_lyrs_grps import InvisibleLayersAndGroups
 from ..user_communication import UserCommunication
-from ..utils import is_number, get_plugin_version, get_flo2dpro_version, qt_cursor_shape
+from ..utils import is_number, get_plugin_version, get_flo2dpro_version, qt_cursor_shape, qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("settings")
@@ -50,7 +50,7 @@ class SettingsDialog(qtBaseClass, uiDialog):
         self.iface = iface
         self.ilg = InvisibleLayersAndGroups(self.iface)
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.setModal(True)
         self.con = con

--- a/flo2d/gui/dlg_stormdrain_shapefile.py
+++ b/flo2d/gui/dlg_stormdrain_shapefile.py
@@ -23,11 +23,12 @@ uiDialog, qtBaseClass = load_ui("storm_drain_shapefile")
 
 class StormDrainShapefile(qtBaseClass, uiDialog):
     def __init__(self, con, iface, layers):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.lyrs = layers
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = con
         self.gutils = GeoPackageUtils(con, iface)

--- a/flo2d/gui/dlg_stormdrain_shapefile.py
+++ b/flo2d/gui/dlg_stormdrain_shapefile.py
@@ -28,7 +28,7 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = layers
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = con
         self.gutils = GeoPackageUtils(con, iface)

--- a/flo2d/gui/dlg_stormdrain_shapefile.py
+++ b/flo2d/gui/dlg_stormdrain_shapefile.py
@@ -15,7 +15,7 @@ from qgis.PyQt.QtWidgets import QApplication, QComboBox, QDialogButtonBox
 from ..flo2d_tools.schema2user_tools import remove_features
 from ..geopackage_utils import GeoPackageUtils, extractPoints
 from ..user_communication import UserCommunication
-from ..utils import is_true, qdialogbuttonbox_button, qt_cursor_shape
+from ..utils import is_true, qdialogbuttonbox_button, qt_cursor_shape, qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("storm_drain_shapefile")

--- a/flo2d/gui/dlg_stormdrain_shapefile.py
+++ b/flo2d/gui/dlg_stormdrain_shapefile.py
@@ -28,7 +28,7 @@ class StormDrainShapefile(qtBaseClass, uiDialog):
         self.iface = iface
         self.lyrs = layers
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = con
         self.gutils = GeoPackageUtils(con, iface)

--- a/flo2d/gui/dlg_update_gpkg.py
+++ b/flo2d/gui/dlg_update_gpkg.py
@@ -16,7 +16,7 @@ from qgis._core import QgsProject, QgsUnitTypes
 
 from .ui_utils import load_ui
 from ..geopackage_utils import GeoPackageUtils
-from ..utils import get_plugin_version, get_flo2dpro_version
+from ..utils import get_plugin_version, get_flo2dpro_version, qt_window_flag
 
 from ..user_communication import UserCommunication
 
@@ -26,11 +26,12 @@ uiDialog, qtBaseClass = load_ui("update_gpkg")
 
 class UpdateGpkg(qtBaseClass, uiDialog):
     def __init__(self, con, iface):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.con = con
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.uc = UserCommunication(iface, "FLO-2D")
 

--- a/flo2d/gui/dlg_walls_shapefile.py
+++ b/flo2d/gui/dlg_walls_shapefile.py
@@ -103,7 +103,7 @@ class WallsShapefile(qtBaseClass, uiDialog):
         try:
             uri = self.walls_shapefile_cbo.itemData(idx)
             lyr_id = self.lyrs.layer_exists_in_group(uri)
-            self.current_lyr = self.lyrs.gget_layer_by_id(lyr_id)
+            self.current_lyr = self.lyrs.get_layer_by_id(lyr_id)
 
             for combo_inlets in self.walls_fields_groupBox.findChildren(QComboBox):
                 combo_inlets.clear()

--- a/flo2d/gui/dlg_walls_shapefile.py
+++ b/flo2d/gui/dlg_walls_shapefile.py
@@ -21,7 +21,7 @@ from qgis.PyQt.QtWidgets import QApplication, QComboBox, QDialogButtonBox
 
 from ..geopackage_utils import GeoPackageUtils, extractPoints
 from ..user_communication import UserCommunication
-from ..utils import float_or_zero, qt_cursor_shape, qdialogbuttonbox_button
+from ..utils import float_or_zero, qt_cursor_shape, qdialogbuttonbox_button, qt_window_flag
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("walls_shapefile")
@@ -29,11 +29,12 @@ uiDialog, qtBaseClass = load_ui("walls_shapefile")
 
 class WallsShapefile(qtBaseClass, uiDialog):
     def __init__(self, con, iface, layers):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.iface = iface
         self.lyrs = layers
         self.setupUi(self)
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.uc = UserCommunication(iface, "FLO-2D")
         self.con = con
         self.gutils = GeoPackageUtils(con, iface)

--- a/flo2d/gui/multiple_domains_editor_widget.py
+++ b/flo2d/gui/multiple_domains_editor_widget.py
@@ -365,7 +365,7 @@ class MultipleDomainsEditorWidget(qtBaseClass, uiDialog):
             fid = fid_qry[0]
         else:
             return
-        new_name, ok = QInputDialog.getText(None, "Change name", "New name:")
+        new_name, ok = QInputDialog.getText(self, "Change name", "New name:")
         if not ok or not new_name:
             return
         if not self.md_name_cbo.findText(new_name) == -1:

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -94,7 +94,7 @@ class INP_GroupsDialog(qtBaseClass, uiDialog):
         self.con = con
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(Qt.Dialog | Qt.Tool)
+        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
         self.gutils = GeoPackageUtils(con, iface)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.polulate_INP_values()

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -74,7 +74,7 @@ from ..gui.dlg_stormdrain_shapefile import StormDrainShapefile
 from ..user_communication import ScrollMessageBox2, UserCommunication,TwoInputsDialog
 from ..utils import float_or_zero, int_or_zero, is_number, is_true, m_fdata, qt_item_role, qt_pen_style, \
     qt_cursor_shape, qt_toolbutton_popup_mode, qt_item_flag, qt_dock_widget_area, qmeta_type, qdialog_code, \
-    qfiledialog_option
+    qfiledialog_option, qt_window_flag
 from .table_editor_widget import CommandItemEdit, StandardItem, StandardItemModel
 from .ui_utils import load_ui, set_icon, try_disconnect, center_canvas, zoom, zoom_cell_buffer
 from ..flo2d_ie.flo2d_parser import ParseDAT

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -6417,12 +6417,10 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         if self.gutils.is_table_empty("user_swmm_inlets_junctions") and \
                 self.gutils.is_table_empty("user_swmm_storage_units"):
             return
-
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
         txt = "Do you want to assign Max. Depth to all nodes that \ndo not have Max. Depth assigned or select the nodes?\n\n" \
               "Max. Depth = Grid Elevation - Invert Elevation\n"
-        dialog = self.uc.dialog_with_2_customized_buttons(
-            "Assign Max. Depth", txt, "All Nodes", "Selected Nodes"
-        )
+        dialog = self.uc.dialog_with_2_customized_buttons("Assign Max. Depth", txt, "All Nodes", "Selected Nodes", parent)
 
         if dialog == self.uc.msgbox_button("Yes"):
             try:

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -89,11 +89,12 @@ uiDialog, qtBaseClass = load_ui("inp_groups")
 
 class INP_GroupsDialog(qtBaseClass, uiDialog):
     def __init__(self, con, iface):
-        qtBaseClass.__init__(self)
+        qtBaseClass.__init__(self, iface.mainWindow())
         uiDialog.__init__(self)
         self.con = con
         self.iface = iface
         self.setupUi(self)
+        self.setWindowFlags(Qt.Dialog | Qt.Tool)
         self.gutils = GeoPackageUtils(con, iface)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.polulate_INP_values()

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from math import isnan, modf
 from pathlib import Path
+from qgis.utils import iface
 
 from ..misc.project_review_utils import SCENARIO_COLOURS, SCENARIO_STYLES
 
@@ -6633,10 +6634,11 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
             else:
                 distance_units = "feet"
 
+            parent = iface.mainWindow() if iface and iface.mainWindow() else None
             dialog = TwoInputsDialog("Do you want to overwrite Inlet and Outfall nodes\n" +
                                      "for all links (conduits, pumps, orifices, and weirs)?",
                                      "Find a node located at a distance\nless than this from the link (in " + distance_units + " )",
-                                     self.buffer_distance, "", 5)
+                                     self.buffer_distance, "", 5, parent)
             if dialog.exec() == qdialog_code("Accepted"):
                 self.buffer_distance = dialog.first_input.value()
             else:

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -74,7 +74,7 @@ from ..gui.dlg_stormdrain_shapefile import StormDrainShapefile
 from ..user_communication import ScrollMessageBox2, UserCommunication,TwoInputsDialog
 from ..utils import float_or_zero, int_or_zero, is_number, is_true, m_fdata, qt_item_role, qt_pen_style, \
     qt_cursor_shape, qt_toolbutton_popup_mode, qt_item_flag, qt_dock_widget_area, qmeta_type, qdialog_code, \
-    qfiledialog_option, qt_window_flag
+    qfiledialog_option, qt_window_flag, mb_role
 from .table_editor_widget import CommandItemEdit, StandardItem, StandardItemModel
 from .ui_utils import load_ui, set_icon, try_disconnect, center_canvas, zoom, zoom_cell_buffer
 from ..flo2d_ie.flo2d_parser import ParseDAT
@@ -3040,7 +3040,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
 
         msg.addButton(QPushButton("Keep existing and complete"), self.uc.msgbox_role("YesRole"))
         msg.addButton(QPushButton("Create new Storm Drains"), self.uc.msgbox_role("NoRole"))
-        msg.addButton(QPushButton("Cancel"), QMessageBox.RejectRole)
+        msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
         msg.setDefaultButton(QMessageBox().Cancel)
         msg.setIcon(QMessageBox.Question)
         ret = msg.exec()

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from math import isnan, modf
 from pathlib import Path
+from qgis.utils import iface
 
 from ..misc.project_review_utils import SCENARIO_COLOURS, SCENARIO_STYLES
 
@@ -3028,7 +3029,8 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         return True
 
     def import_INP_action(self):
-        msg = QMessageBox()
+        parent = iface.mainWindo() if iface and iface.mainWindow() else None
+        msg = QMessageBox(parent)
         msg.setWindowTitle("Replace or complete Storm Drain User Data")
         msg.setText(
             "There is already Storm Drain data in the Users Layers.\n\nWould you like to keep it and complete it with data taken from the .INP file?\n\n"

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -3041,7 +3041,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         msg.addButton(QPushButton("Keep existing and complete"), self.uc.msgbox_role("YesRole"))
         msg.addButton(QPushButton("Create new Storm Drains"), self.uc.msgbox_role("NoRole"))
         msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
-        msg.setDefaultButton(QMessageBox().Cancel)
+        msg.setDefaultButton(self.uc.msgbox_button("Cancel"))
         msg.setIcon(QMessageBox.Question)
         ret = msg.exec()
         if ret == 0:

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -3042,7 +3042,7 @@ class StormDrainEditorWidget(qtBaseClass, uiDialog):
         msg.addButton(QPushButton("Create new Storm Drains"), self.uc.msgbox_role("NoRole"))
         msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
         msg.setDefaultButton(self.uc.msgbox_button("Cancel"))
-        msg.setIcon(QMessageBox.Question)
+        msg.setIcon(self.uc.msgbox_icon("Question"))
         ret = msg.exec()
         if ret == 0:
             return "Keep and Complete"

--- a/flo2d/gui/storm_drain_editor_widget.py
+++ b/flo2d/gui/storm_drain_editor_widget.py
@@ -94,7 +94,7 @@ class INP_GroupsDialog(qtBaseClass, uiDialog):
         self.con = con
         self.iface = iface
         self.setupUi(self)
-        self.setWindowFlags(qt_window_flag(Qt.Dialog) | qt_window_flag(Qt.Tool))
+        self.setWindowFlags(qt_window_flag("Dialog") | qt_window_flag("Tool"))
         self.gutils = GeoPackageUtils(con, iface)
         self.uc = UserCommunication(iface, "FLO-2D")
         self.polulate_INP_values()

--- a/flo2d/gui/table_editor_widget.py
+++ b/flo2d/gui/table_editor_widget.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 from ..user_communication import UserCommunication
-from ..utils import is_number, qt_item_role, qt_cursor_shape, qevent_type, qt_keyboard_modifier
+from ..utils import is_number, qt_item_role, qt_cursor_shape, qevent_type, qt_keyboard_modifier, qt_key
 from .ui_utils import load_ui
 
 uiDialog, qtBaseClass = load_ui("table_editor")
@@ -201,12 +201,12 @@ class TableEditorEventFilter(QObject):
     def eventFilter(self, receiver, event):
         if event.type() == qevent_type("KeyPress"):
             if event.modifiers() & qt_keyboard_modifier("ControlModifier"):
-                if event.key() == Qt.Key_C:
+                if event.key() == qt_key("Key_C"):
                     table_editor_widget = receiver.parent()
                     if isinstance(table_editor_widget, TableEditorWidget):
                         table_editor_widget.copy_selection()
                     return True
-                elif event.key() == Qt.Key_V:
+                elif event.key() == qt_key("Key_V"):
                     table_editor_widget = receiver.parent()
                     if isinstance(table_editor_widget, TableEditorWidget):
                         table_editor_widget.paste()

--- a/flo2d/gui/xs_editor_widget.py
+++ b/flo2d/gui/xs_editor_widget.py
@@ -1323,7 +1323,7 @@ class XsecEditorWidget(qtBaseClass, uiDialog):
                             msg.addButton(QPushButton("Run CHANRIGHTBANK.EXE"), self.uc.msgbox_role("NoRole"))
                             msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
                             msg.setDefaultButton(self.uc.msgbox_button("Cancel"))
-                            msg.setIcon(QMessageBox.Question)
+                            msg.setIcon(self.uc.msgbox_icon("Question"))
                             ret = msg.exec()
                             if ret == 0:
                                 s = QSettings()

--- a/flo2d/gui/xs_editor_widget.py
+++ b/flo2d/gui/xs_editor_widget.py
@@ -57,7 +57,7 @@ from ..geopackage_utils import GeoPackageUtils
 from ..gui.dlg_tributaries import TributariesDialog
 from ..misc.project_review_utils import hychan_dataframe_from_hdf5_scenarios, SCENARIO_COLOURS, SCENARIO_STYLES
 from ..user_communication import UserCommunication
-from ..utils import is_number, m_fdata, qt_item_role, qt_pen_style, qt_cursor_shape, qt_item_flag, qt_dock_widget_area
+from ..utils import is_number, m_fdata, qt_item_role, qt_pen_style, qt_cursor_shape, qt_item_flag, qt_dock_widget_area, mb_role
 from .plot_widget import PlotWidget
 from .table_editor_widget import StandardItem, StandardItemModel
 from .ui_utils import (
@@ -1321,7 +1321,7 @@ class XsecEditorWidget(qtBaseClass, uiDialog):
                                 self.uc.msgbox_button("Yes"),
                             )
                             msg.addButton(QPushButton("Run CHANRIGHTBANK.EXE"), self.uc.msgbox_role("NoRole"))
-                            msg.addButton(QPushButton("Cancel"), QMessageBox.RejectRole)
+                            msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
                             msg.setDefaultButton(QMessageBox().Cancel)
                             msg.setIcon(QMessageBox.Question)
                             ret = msg.exec()

--- a/flo2d/gui/xs_editor_widget.py
+++ b/flo2d/gui/xs_editor_widget.py
@@ -1322,7 +1322,7 @@ class XsecEditorWidget(qtBaseClass, uiDialog):
                             )
                             msg.addButton(QPushButton("Run CHANRIGHTBANK.EXE"), self.uc.msgbox_role("NoRole"))
                             msg.addButton(QPushButton("Cancel"), mb_role("RejectRole"))
-                            msg.setDefaultButton(QMessageBox().Cancel)
+                            msg.setDefaultButton(self.uc.msgbox_button("Cancel"))
                             msg.setIcon(QMessageBox.Question)
                             ret = msg.exec()
                             if ret == 0:

--- a/flo2d/layers.py
+++ b/flo2d/layers.py
@@ -26,7 +26,7 @@ from qgis.core import (
     QgsWkbTypes,
 )
 from qgis.gui import QgsRubberBand
-from qgis.PyQt.QtCore import Qt
+from qgis.utils import iface
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import QApplication
 
@@ -2424,7 +2424,8 @@ class Layers(object):
         self.collapse_all_flo2d_groups()
         self.group = group
 
-        pd = QProgressDialog("Loading layers...", None, 0, len(self.data))
+        parent = iface.mainWindow() if iface and iface.mainWindow() else None
+        pd = QProgressDialog("Loading layers...", None, 0, len(self.data), parent)
         pd.setWindowTitle("Loading layers")
         pd.setModal(True)
         pd.forceShow()
@@ -2494,6 +2495,9 @@ class Layers(object):
             i += 1
             QApplication.processEvents()
             pd.setValue(i)
+
+        pd.close()
+        pd.deleteLater()
 
         s = QSettings()
         s.setValue("FLO-2D/advanced_layers", False)

--- a/flo2d/user_communication.py
+++ b/flo2d/user_communication.py
@@ -330,8 +330,8 @@ class ScrollMessageBox2(QMessageBox):
         chldn[1].setText("")
 
 class TwoInputsDialog(QDialog):
-    def __init__(self, label_text, first_label, first_value, second_label, second_value):
-        super(TwoInputsDialog, self).__init__()
+    def __init__(self, label_text, first_label, first_value, second_label, second_value, parent=None):
+        super(TwoInputsDialog, self).__init__(parent)
 
         self.setWindowTitle("FLO-2D")
         self.label = QLabel(label_text, self)

--- a/flo2d/user_communication.py
+++ b/flo2d/user_communication.py
@@ -208,8 +208,8 @@ class UserCommunication(object):
         else:
             print(msg)
 
-    def dialog_with_2_customized_buttons(self, title, msg, text1, text2):
-        msgBox = QMessageBox()
+    def dialog_with_2_customized_buttons(self, title, msg, text1, text2, parent=None):
+        msgBox = QMessageBox(parent)
         msgBox.setWindowTitle(title)
         if msg != "":
             msgBox.setText(msg)

--- a/flo2d/user_communication.py
+++ b/flo2d/user_communication.py
@@ -34,7 +34,7 @@ from qgis.PyQt.QtWidgets import (
 from qgis.PyQt.QtGui import QFont
 from qgis.utils import iface
 
-from flo2d.utils import qt_window_modality, qt_window_type, qt_alignment_flag, mb_button, qsizepolicy_policy
+from flo2d.utils import qt_window_modality, qt_window_type, qt_alignment_flag, mb_button, qsizepolicy_policy, mb_icon
 
 
 def is_file_locked(filepath):
@@ -95,7 +95,7 @@ class UserCommunication(object):
             msgBox.setWindowTitle("FLO-2D")
             icon = QMessageBox.Information if type=="info" else + \
                     QMessageBox.Warning if type=="warning" else + \
-                    QMessageBox.Critical if type=="error" else QMessageBox.Information
+                    mb_icon("Critical") if type=="error" else QMessageBox.Information
             msgBox.setIcon(icon)
             horizontalSpacer = QSpacerItem(hSize, 0, qsizepolicy_policy("Minimum"), qsizepolicy_policy("Expanding"))
             layout = msgBox.layout()
@@ -114,7 +114,7 @@ class UserCommunication(object):
 
     def show_critical(self, msg):
         if self.iface is not None:
-            QMessageBox.critical(self.iface.mainWindow(), self.context, msg)
+            mb_icon("Critical")(self.iface.mainWindow(), self.context, msg)
         else:
             print(msg)
 
@@ -128,7 +128,7 @@ class UserCommunication(object):
 
             formatted_lines = traceback.format_exc().splitlines()
 
-            QMessageBox.critical(
+            mb_icon("Critical")(
                 self.iface.mainWindow(),
                 self.context,
                 msg

--- a/flo2d/user_communication.py
+++ b/flo2d/user_communication.py
@@ -34,7 +34,7 @@ from qgis.PyQt.QtWidgets import (
 from qgis.PyQt.QtGui import QFont
 from qgis.utils import iface
 
-from flo2d.utils import qt_window_modality, qt_window_type, qt_alignment_flag, mb_button, qsizepolicy_policy, mb_icon
+from flo2d.utils import qt_window_modality, qt_window_type, qt_alignment_flag, mb_button, qsizepolicy_policy
 
 
 def is_file_locked(filepath):
@@ -95,7 +95,7 @@ class UserCommunication(object):
             msgBox.setWindowTitle("FLO-2D")
             icon = QMessageBox.Information if type=="info" else + \
                     QMessageBox.Warning if type=="warning" else + \
-                    mb_icon("Critical") if type=="error" else QMessageBox.Information
+                    QMessageBox.Critical if type=="error" else QMessageBox.Information
             msgBox.setIcon(icon)
             horizontalSpacer = QSpacerItem(hSize, 0, qsizepolicy_policy("Minimum"), qsizepolicy_policy("Expanding"))
             layout = msgBox.layout()
@@ -114,7 +114,7 @@ class UserCommunication(object):
 
     def show_critical(self, msg):
         if self.iface is not None:
-            mb_icon("Critical")(self.iface.mainWindow(), self.context, msg)
+            QMessageBox.critical(self.iface.mainWindow(), self.context, msg)
         else:
             print(msg)
 
@@ -128,7 +128,7 @@ class UserCommunication(object):
 
             formatted_lines = traceback.format_exc().splitlines()
 
-            mb_icon("Critical")(
+            QMessageBox.critical(
                 self.iface.mainWindow(),
                 self.context,
                 msg

--- a/flo2d/utils.py
+++ b/flo2d/utils.py
@@ -344,7 +344,7 @@ def Msge(msg_string, icon):
     if icon == "Info":
         msgBox.setIcon(QMessageBox.Information)
     elif icon == "Error":
-        msgBox.setIcon(QMessageBox.Critical)
+        msgBox.setIcon(mb_icon("Critical"))
     elif icon == "Warning":
         msgBox.setIcon(QMessageBox.Warning)
     msgBox.setText(msg_string)

--- a/flo2d/utils.py
+++ b/flo2d/utils.py
@@ -655,3 +655,8 @@ def mb_icon(name):
     if hasattr(QMessageBox, "Icon"): #Qt6
         return getattr(QMessageBox.Icon, name)
     return getattr(QMessageBox, name) #Qt5
+
+def mb_role(name):
+    if hasattr(QMessageBox, "ButtonRole"): #Qt6
+        return getattr(QMessageBox.ButtonRole, name)
+    return getattr(QMessageBox, name) #Qt5

--- a/flo2d/utils.py
+++ b/flo2d/utils.py
@@ -650,3 +650,8 @@ def qt_window_flag(name):
     if hasattr(Qt, "WindowType"): # Qt6
         return getattr(Qt.WindowType, name)
     return getattr(Qt, name) #Qt5
+
+def mb_icon(name):
+    if hasattr(QMessageBox, "Icon"): #Qt6
+        return getattr(QMessageBox.Icon, name)
+    return getattr(QMessageBox, name) #Qt5

--- a/flo2d/utils.py
+++ b/flo2d/utils.py
@@ -660,3 +660,8 @@ def mb_role(name):
     if hasattr(QMessageBox, "ButtonRole"): #Qt6
         return getattr(QMessageBox.ButtonRole, name)
     return getattr(QMessageBox, name) #Qt5
+
+def qt_key(name):
+    if hasattr(Qt, "Key"): # Qt6
+        return getattr(Qt.Key, name)
+    return getattr(Qt, name) # Qt5


### PR DESCRIPTION
- Ensure dialogs (including progress dialogs) are parented to QGIS (not any other active app/screen/window/monitor), and that aftewards, their stale/ghost previews are not shown when one hovers over QGIS app from the taskbar.

- Resolve Qt issues (Qt5 vs Qt6) related to the issue "Open windows on qgis not second screen #1987"

- Correct the typo in "self.current_lyr = self.lyrs.gget_layer_by_id(lyr_id)" to "self.current_lyr = self.lyrs.gget_layer_by_id(lyr_id)" in dlg_walls-shapefile.py file