### PR TITLE
Inspect-values-seems-to-default-on-until-you-check-the-box-and-then-uncheck-it-#2130

### DIFF
--- a/flo2d/gui/plot_widget.py
+++ b/flo2d/gui/plot_widget.py
@@ -383,7 +383,7 @@ class PlotWidget(QWidget):
         self.plot.autoRange()
 
     def toggle_hover(self, state):
-        self.hover_enabled = bool(state)
+        self.hover_enabled = (state == qt_check_state("Checked"))
 
         if not self.hover_enabled:
             # Hide overlays immediately


### PR DESCRIPTION
replace the line "self.hover_enabled = bool(state)" with "self.hover_enabled = (state == qt_check_state("Checked"))" to ensure the hover feature in the FLO-2D plot panel does not start enabled (in Qt6) even though the checkbox is unchecked.