### PR TITLE
Prescribed breach inconsitency #2158

### DIFF
--- a/flo2d/flo2d_tools/schematic_tools.py
+++ b/flo2d/flo2d_tools/schematic_tools.py
@@ -14,6 +14,7 @@ from math import pi, sqrt
 from operator import itemgetter
 
 import numpy as np
+from qgis.PyQt.QtCore import NULL
 from qgis.core import (
     QgsFeature,
     QgsFeatureRequest,
@@ -307,10 +308,6 @@ def generate_schematic_levees(gutils, levee_lyr, grid_lyr):
             ins_levees_sql = """INSERT INTO levee_data (grid_fid, ldir, levcrest, user_line_fid, geom)
                          VALUES (?,?,?,?, AsGPB(ST_GeomFromText(?)));"""
 
-            levee_failure_qry = """SELECT failevel, failtime, levbase, failwidthmax, failrate, failwidrate
-                                    FROM levee_failure 
-                                    WHERE grid_fid = ?"""
-
             ins_levees_failure_sql = """INSERT INTO levee_failure (grid_fid, lfaildir, failevel, failtime,
                                                               levbase, failwidthmax, failrate, failwidrate)
                                          VALUES (?,?,?,?,?,?,?,?);"""
@@ -340,8 +337,8 @@ def generate_schematic_levees(gutils, levee_lyr, grid_lyr):
 
                                 user_levees_data = gutils.con.execute(select_user_levees_qry, (lid,)).fetchone()
                                 if user_levees_data:
-                                    if not all(v == 0 for v in user_levees_data):
-                                        if not user_levees_data[0] == 0.0:
+                                    if not all(v in (0, NULL) for v in user_levees_data): # Treat both 0 and NULL as unset user levee values.
+                                        if user_levees_data[0] not in (NULL, 0):
                                             # failElev selected, use it.
                                             fail_data.append(
                                                 (
@@ -355,7 +352,7 @@ def generate_schematic_levees(gutils, levee_lyr, grid_lyr):
                                                     user_levees_data[6],
                                                 )
                                             )
-                                        elif not user_levees_data[1] == 0.0:
+                                        elif user_levees_data[1] not in (NULL, 0):
                                             # failDepth selected, use adjacent cell elevations to calculate fail elevation.
 
                                             (
@@ -380,7 +377,7 @@ def generate_schematic_levees(gutils, levee_lyr, grid_lyr):
                                         else:  # do not set failure data for this direction.
                                             pass
 
-                                        if user_levees_data[7] is None:  # crest elevation in user levees not defined
+                                        if user_levees_data[7] is NULL:  # crest elevation in user levees not defined
                                             (
                                                 adj_cell,
                                                 adj_elev,

--- a/flo2d/gui/dlg_breach.py
+++ b/flo2d/gui/dlg_breach.py
@@ -74,7 +74,12 @@ def repaint_levee(gutils, levees_layer):
 
     # check
     failure_mode_qry = """SELECT ilevfail FROM levee_general"""
-    failure_mode = gutils.execute(failure_mode_qry).fetchall()[0][0]
+
+    # Get the failure mode that controls levee symbology.
+    # If levee_general is empty or ilevfail is NULL, treat it as 0 ("No failure")
+    # so the renderer can still be built instead of failing on fetchall()[0][0].
+    failure_mode_row = gutils.execute(failure_mode_qry).fetchone()
+    failure_mode = failure_mode_row[0] if failure_mode_row and failure_mode_row[0] is not None else 0
 
     # create a new rule-based renderer
     symbol = QgsSymbol.defaultSymbol(levees_layer.geometryType())
@@ -1590,6 +1595,12 @@ class IndividualLeveesDialog(qtBaseClass, uiDialog_individual_levees):
                 self.lyrs.data["levee_failure"]["qlyr"],
             ]
             self.lyrs.repaint_layers()
+
+            # Ensure levee_general exists and prescribed failure mode is active
+            if self.gutils.is_table_empty("levee_general"):
+                self.gutils.execute("INSERT INTO levee_general DEFAULT VALUES;")
+
+            self.gutils.execute("UPDATE levee_general SET ilevfail = 1;")
 
             levees = self.lyrs.data["levee_data"]["qlyr"]
             repaint_levee(self.gutils, levees)

--- a/flo2d/gui/levee_and_breach_editor_widget.py
+++ b/flo2d/gui/levee_and_breach_editor_widget.py
@@ -132,7 +132,7 @@ class LeveeAndBreachEditorWidget(qtBaseClass, uiDialog):
                 self.uc.log_info(f"ERROR: {e}")
 
             schem_levee = self.lyrs.data['levee_data']["qlyr"]
-            schem_levee.triggerRepaint()
+            repaint_levee(self.gutils, schem_levee) # Rebuild the levee renderer after data changes
             QApplication.restoreOverrideCursor()
             self.uc.bar_info(f"Schematized levees deleted.")
             self.uc.log_info(f"Schematized levees deleted.")


### PR DESCRIPTION
- Rebuild levee renderer instead of only triggering repaint
- Safely handle missing or NULL levee failure mode values
- Treat NULL and 0 user levee fields as unset when generating failure data