### PR TITLE
Infiltration errors when coverage is off #2136 (CN)

### DIFF
--- a/flo2d/flo2d_tools/grid_tools.py
+++ b/flo2d/flo2d_tools/grid_tools.py
@@ -932,9 +932,10 @@ def centroids2poly_geos(base_polygons, polygons, request=None, *columns):
     for feat in base_features:
         base_geom = feat.geometry().centroid()
         fids = index.intersects(base_geom.boundingBox())
-        if not fids:
-            continue
         base_fid = feat.id()
+        if not fids:
+            yield base_fid, [] # allow processing even those grids without intersection to all assignment of default value
+            continue
         base_geom_geos = base_geom.constGet()
         base_geom_engine = QgsGeometry.createGeometryEngine(base_geom_geos)
         base_geom_engine.prepareGeometry()

--- a/flo2d/flo2d_tools/infiltration_tools.py
+++ b/flo2d/flo2d_tools/infiltration_tools.py
@@ -428,16 +428,20 @@ class InfiltrationCalculator(object):
         """
         This code sets the CN based on the centroid of the intersecting layer.
         """
+        grid_params = {}
+        default_count = 0
+        default_cn = self.gutils.execute("SELECT scsnall FROM infil").fetchone()[0]
         try:
-            grid_params = {}
             curve_values = centroids2poly_geos(self.grid_lyr, self.curve_lyr, None, self.curve_fld)
+
             for gid, values in curve_values:
                 if len(values) == 0:
-                    raise Exception("Grid element centroid is not inside the Infiltration Polygon.")
+                    cn = default_cn
+                    default_count += 1
                 else:
                     cn = values[0][0]
-                    grid_params[gid] = {"scsn": cn}
-            return grid_params
+                grid_params[gid] = {"scsn": cn}
+            return grid_params, default_count, default_cn
 
         except Exception as e:
             self.uc.show_error(

--- a/flo2d/flo2d_tools/infiltration_tools.py
+++ b/flo2d/flo2d_tools/infiltration_tools.py
@@ -492,14 +492,20 @@ class InfiltrationCalculator(object):
         sampler = raster2grid(self.grid_lyr, temp_file_path, iface)
 
         grid_params = {}
+        default_count = 0
+
+        default_cn = self.gutils.execute("SELECT scsnall FROM infil").fetchone()[0]
+
         for cn, gid in sampler:
             if cn is None:
-                cn = self.gutils.execute("SELECT scsnall FROM infil").fetchone()[0]
+                cn = default_cn
+                default_count += 1
+
             grid_params[gid] = {"scsn": int(round(cn, 0))}
 
         os.remove(temp_file_path)
 
-        return grid_params
+        return grid_params, default_count, default_cn
 
     def scs_infiltration_multi(self):
         grid_params = {}

--- a/flo2d/gui/infil_editor_widget.py
+++ b/flo2d/gui/infil_editor_widget.py
@@ -655,17 +655,12 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
             self.con.commit()
             self.gutils.enable_geom_triggers()
             QApplication.restoreOverrideCursor()
-            msg = (
-                "Calculating SCS Curve Number parameters finished!\n"
-                "The Calculated infiltration data was added to the schematized data."
-            )
-
+            msg = ("Calculating SCS Curve Number parameters finished!\n"
+                "The Calculated infiltration data was added to the schematized data.")
             if default_count > 0:
-                msg += (
-                    f"\n\nThe CN layer did not completely cover the computational grid.\n"
+                msg += (f"\n\nThe CN layer did not completely cover the computational grid.\n"
                     f"A Global SCS CN value ({default_cn:}) "
-                    f"was assigned to cells outside the layer coverage."
-                )
+                    f"was assigned to cells outside the layer coverage.")
             self.uc.show_info(msg)
             self.uc.log_info(msg)
         except Exception as e:

--- a/flo2d/gui/infil_editor_widget.py
+++ b/flo2d/gui/infil_editor_widget.py
@@ -627,6 +627,7 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
         ok = dlg.exec()
         if not ok:
             return
+        default_count = 0
         try:
             QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
             self.gutils.disable_geom_triggers()
@@ -638,7 +639,7 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
             elif dlg.raster_grp.isChecked():
                 raster_lyr, algorithm, nodatavalue, fillnodata, multithread = dlg.raster_scs_parameters()
                 inf_calc.setup_scs_raster(raster_lyr, algorithm, nodatavalue, fillnodata, multithread)
-                grid_params = inf_calc.scs_infiltration_raster()
+                grid_params, default_count, default_cn = inf_calc.scs_infiltration_raster()
             else:
                 multi_lyr, multi_fields = dlg.multi_scs_parameters()
                 inf_calc.setup_scs_multi(multi_lyr, *multi_fields)
@@ -654,10 +655,19 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
             self.con.commit()
             self.gutils.enable_geom_triggers()
             QApplication.restoreOverrideCursor()
-            self.uc.show_info("Calculating SCS Curve Number parameters finished! \n"
-                             "The Calculated infiltration data was added to the schematized data.")
-            self.uc.log_info("Calculating SCS Curve Number parameters finished! \n"
-                             "The Calculated infiltration data was added to the schematized data.")
+            msg = (
+                "Calculating SCS Curve Number parameters finished! \n"
+                "The Calculated infiltration data was added to the schematized data."
+            )
+
+            if default_count > 0:
+                msg += (
+                    f"\n\n The CN raster did not completely cover the computational grid. "
+                    f"The Global SCS CN value ({default_cn})"
+                    f"was used for the missing infiltration values."
+                )
+            self.uc.show_info(msg)
+            self.uc.log_info(msg)
         except Exception as e:
             self.uc.log_info(traceback.format_exc())
             self.uc.show_warn(

--- a/flo2d/gui/infil_editor_widget.py
+++ b/flo2d/gui/infil_editor_widget.py
@@ -635,7 +635,7 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
             if dlg.single_grp.isChecked():
                 single_lyr, single_fields = dlg.single_scs_parameters()
                 inf_calc.setup_scs_single(single_lyr, *single_fields)
-                grid_params = inf_calc.scs_infiltration_single()
+                grid_params, default_count, default_cn = inf_calc.scs_infiltration_single()
             elif dlg.raster_grp.isChecked():
                 raster_lyr, algorithm, nodatavalue, fillnodata, multithread = dlg.raster_scs_parameters()
                 inf_calc.setup_scs_raster(raster_lyr, algorithm, nodatavalue, fillnodata, multithread)
@@ -656,15 +656,15 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
             self.gutils.enable_geom_triggers()
             QApplication.restoreOverrideCursor()
             msg = (
-                "Calculating SCS Curve Number parameters finished! \n"
+                "Calculating SCS Curve Number parameters finished!\n"
                 "The Calculated infiltration data was added to the schematized data."
             )
 
             if default_count > 0:
                 msg += (
-                    f"\n\n The CN raster did not completely cover the computational grid. "
-                    f"The Global SCS CN value ({default_cn})"
-                    f"was used for the missing infiltration values."
+                    f"\n\nThe CN layer did not completely cover the computational grid.\n"
+                    f"A Global SCS CN value ({default_cn:}) "
+                    f"was assigned to cells outside the layer coverage."
                 )
             self.uc.show_info(msg)
             self.uc.log_info(msg)
@@ -672,7 +672,9 @@ class InfilEditorWidget(qtBaseClass, uiDialog):
             self.uc.log_info(traceback.format_exc())
             self.uc.show_warn(
                 "WARNING 060319.1724: Calculating SCS Curve Number parameters failed! \n"
-                "Please check that the Raster covers the Grid Layer and the coordinate system is valid."
+                "Please check your input data and try again.\n"
+                "__________________________________________________",
+                e,
             )
         finally:
             dlg.deleteLater()


### PR DESCRIPTION
- when the cn polygon/raster did not cover the whole computational domain, let the user know a default value of "xx" was used for the  affected grids
- allow processing even those grids without intersection to all assignment of default value (polygon layer)