### PR TITLE
Include-CADPTS.DAT-and-FPLAIN.DAT-during-normal-export-of-DAT-files-#2200

### DIFF
--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -3085,6 +3085,9 @@ class Flo2D(object):
         if "Manning's n and Topo" not in dlg_components.components:
             export_calls.remove("export_mannings_n_topo")
 
+        if "Cadpts and Fplain" not in dlg_components.components:
+            export_calls.remove("export_cadpts_fplain")
+
         if "Spatial Steep Slope-n" not in dlg_components.components:
             export_calls.remove("export_steep_slopen")
 

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -1753,6 +1753,8 @@ class Flo2D(object):
                             self.files_used += "SWMM.INP" + "\n"
                         if dat == "TOPO.DAT":
                             self.files_used += "MANNINGS_N.DAT" + "\n"
+                        if dat == "FPLAIN.DAT":
+                            self.files_used += "CADPTS.DAT" + "\n"
                         if dat == "MULT.DAT":
                             self.files_used += "SIMPLE_MULT.DAT" + "\n"
                         pass

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -2702,6 +2702,7 @@ class Flo2D(object):
                             "export_levee",
                             "export_lid_volume",
                             "export_mannings_n_topo",
+                            "export_cadpts_fplain",
                             "export_mult",
                             "export_outflow",
                             "export_outrc",

--- a/flo2d/flo2d.py
+++ b/flo2d/flo2d.py
@@ -2728,6 +2728,9 @@ class Flo2D(object):
 
             dlg_components = ComponentsDialog(self.con, self.iface, self.lyrs, "out")
 
+            if export_type == "hdf5":
+                dlg_components.set_cadpts_fplain_enabled(False) # Uncheck and disable cadpts and fplain checkbox
+
             if quick_run:
                 dlg_components.data_rb.setVisible(True)
                 dlg_components.hdf5_rb.setVisible(True)

--- a/flo2d/flo2d_ie/flo2dgeopackage.py
+++ b/flo2d/flo2d_ie/flo2dgeopackage.py
@@ -10,6 +10,7 @@
 import os
 import shutil
 import traceback
+import math
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 from itertools import chain, groupby
@@ -9120,7 +9121,8 @@ class Flo2dGeoPackage(GeoPackageUtils):
                     ST_AsText(ST_Centroid(GeomFromGPB(geom)))
                     FROM grid ORDER BY fid;"""
                 )
-                records = self.execute(sql)
+                
+                records = list(self.execute(sql))
             else:
                 sub_grid_cells = self.gutils.execute(
                     f"""SELECT DISTINCT
@@ -9143,10 +9145,31 @@ class Flo2dGeoPackage(GeoPackageUtils):
 
             nulls = 0
 
-            neighbors = grid_compas_neighbors(self.gutils)
+            # Build a centroid-to-FID lookup from the grid records already retrieved above.
+            cell_size = float(self.gutils.get_cont_par("CELLSIZE"))
+            centroid_map = {}
+            for fid, man, elev, geom in records:
+                x, y = geom.strip("POINT()").split()
+                centroid_map[(float(x), float(y))] = fid
+
+            # FPLAIN.DAT requires only the four cardinal neighbors (N, E, S, W).
+            # Calculate them directly from the grid records to avoid the overhead
+            # of the general-purpose grid_compas_neighbors() function.
+            cardinal_neighbors = []
+            for fid, man, elev, geom in records:
+                x, y = geom.strip("POINT()").split()
+                x = float(x)
+                y = float(y)
+
+                north = centroid_map.get((x, y + cell_size), 0)
+                east = centroid_map.get((x + cell_size, y), 0)
+                south = centroid_map.get((x, y - cell_size), 0)
+                west = centroid_map.get((x - cell_size, y), 0)
+
+                cardinal_neighbors.append([north, east, south, west])
 
             with open(cadpts, "w") as c, open(fplain, "w") as f:
-                for row, neighbor_row in zip(records, neighbors):
+                for row, neighbor_row in zip(records, cardinal_neighbors):
                     fid, man, elev, geom = row
 
                     if man == None or elev == None:
@@ -9161,8 +9184,8 @@ class Flo2dGeoPackage(GeoPackageUtils):
                     c.write(
                         cline.format(
                             fid,
-                            "{0: .3f}".format(float(x)),
-                            "{0: .3f}".format(float(y)),
+                            f"{math.trunc(float(x) * 10000) / 10000: .4f}",
+                            f"{math.trunc(float(y) * 10000) / 10000: .4f}",
                         )
                     )
 
@@ -9177,7 +9200,6 @@ class Flo2dGeoPackage(GeoPackageUtils):
                             "{0: .2f}".format(float(elev)),
                         )
                     )
-
             if nulls > 0:
                 QApplication.restoreOverrideCursor()
                 self.uc.show_warn(
@@ -9188,6 +9210,7 @@ class Flo2dGeoPackage(GeoPackageUtils):
                     + "Please check the source layer coverage or use Fill Nodata."
                 )
                 QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
+
             return True
 
         except Exception as e:
@@ -9198,7 +9221,6 @@ class Flo2dGeoPackage(GeoPackageUtils):
             )
             QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
             return False
-
 
     # def export_neighbours(self):
     #     if self.parsed_format == self.FORMAT_DAT:

--- a/flo2d/flo2d_ie/flo2dgeopackage.py
+++ b/flo2d/flo2d_ie/flo2dgeopackage.py
@@ -9108,6 +9108,98 @@ class Flo2dGeoPackage(GeoPackageUtils):
             QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
             return False
 
+    def export_cadpts_fplain(self, output=None, subdomain=None):
+        if self.parsed_format == self.FORMAT_DAT:
+            return self.export_cadpts_fplain_dat(output, subdomain)
+
+    def export_cadpts_fplain_dat(self, outdir, subdomain):
+        try:
+            if not subdomain:
+                sql = (
+                    """SELECT fid, n_value, elevation,
+                    ST_AsText(ST_Centroid(GeomFromGPB(geom)))
+                    FROM grid ORDER BY fid;"""
+                )
+                records = self.execute(sql)
+            else:
+                sub_grid_cells = self.gutils.execute(
+                    f"""SELECT DISTINCT
+                            md.domain_cell,
+                            g.n_value,
+                            g.elevation,
+                            ST_AsText(ST_Centroid(GeomFromGPB(g.geom)))
+                        FROM grid g
+                        JOIN schema_md_cells md ON g.fid = md.grid_fid
+                        WHERE md.domain_fid = {subdomain};"""
+                ).fetchall()
+
+                records = sorted(sub_grid_cells, key=lambda x: x[0])
+
+            cadpts = os.path.join(outdir, "CADPTS.DAT")
+            fplain = os.path.join(outdir, "FPLAIN.DAT")
+
+            cline = "{0: >9} {1: >14} {2: >14}\n"
+            fline = "{0: >9} {1: >8} {2: >8} {3: >8} {4: >8} {5: >7} {6: >9}\n"
+
+            nulls = 0
+
+            neighbors = grid_compas_neighbors(self.gutils)
+
+            with open(cadpts, "w") as c, open(fplain, "w") as f:
+                for row, neighbor_row in zip(records, neighbors):
+                    fid, man, elev, geom = row
+
+                    if man == None or elev == None:
+                        nulls += 1
+                        if man == None:
+                            man = 0.04
+                        if elev == None:
+                            elev = -9999
+
+                    x, y = geom.strip("POINT()").split()
+
+                    c.write(
+                        cline.format(
+                            fid,
+                            "{0: .3f}".format(float(x)),
+                            "{0: .3f}".format(float(y)),
+                        )
+                    )
+
+                    f.write(
+                        fline.format(
+                            fid,
+                            neighbor_row[0],
+                            neighbor_row[1],
+                            neighbor_row[2],
+                            neighbor_row[3],
+                            "{0: .3f}".format(float(man)),
+                            "{0: .2f}".format(float(elev)),
+                        )
+                    )
+
+            if nulls > 0:
+                QApplication.restoreOverrideCursor()
+                self.uc.show_warn(
+                    "WARNING 281122.0541: there are "
+                    + str(nulls)
+                    + " NULL values in the Grid layer's elevation or n_value fields.\n\n"
+                    + "Default values were written to the exported files.\n\n"
+                    + "Please check the source layer coverage or use Fill Nodata."
+                )
+                QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
+            return True
+
+        except Exception as e:
+            QApplication.restoreOverrideCursor()
+            self.uc.show_error(
+                "ERROR 101218.1541: exporting CADPTS.DAT or FPLAIN.DAT failed!\n",
+                e,
+            )
+            QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
+            return False
+
+
     # def export_neighbours(self):
     #     if self.parsed_format == self.FORMAT_DAT:
     #         raise NotImplementedError("Exporting NEIGHBOURS.DAT is not supported!")

--- a/flo2d/flo2d_ie/flo2dgeopackage.py
+++ b/flo2d/flo2d_ie/flo2dgeopackage.py
@@ -10,7 +10,6 @@
 import os
 import shutil
 import traceback
-import math
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 from itertools import chain, groupby
@@ -36,6 +35,7 @@ from ..gui.dlg_settings import SettingsDialog
 from ..layers import Layers
 from ..utils import float_or_zero, get_BC_Border, get_flo2dpro_release_date, qt_cursor_shape
 from .flo2d_parser import ParseDAT, ParseHDF5
+
 
 
 def create_array(line_format, max_columns, array_type, *args):
@@ -9184,8 +9184,8 @@ class Flo2dGeoPackage(GeoPackageUtils):
                     c.write(
                         cline.format(
                             fid,
-                            f"{math.trunc(float(x) * 10000) / 10000: .4f}",
-                            f"{math.trunc(float(y) * 10000) / 10000: .4f}",
+                            "{0: .4f}".format(float(x)),
+                            "{0: .4f}".format(float(y)),
                         )
                     )
 
@@ -9210,7 +9210,6 @@ class Flo2dGeoPackage(GeoPackageUtils):
                     + "Please check the source layer coverage or use Fill Nodata."
                 )
                 QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
-
             return True
 
         except Exception as e:
@@ -9221,6 +9220,7 @@ class Flo2dGeoPackage(GeoPackageUtils):
             )
             QApplication.setOverrideCursor(qt_cursor_shape("WaitCursor"))
             return False
+
 
     # def export_neighbours(self):
     #     if self.parsed_format == self.FORMAT_DAT:

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -42,9 +42,17 @@ class ComponentsDialog(qtBaseClass, uiDialog):
         self.components_buttonBox.accepted.connect(self.select_components)
         self.select_all_chbox.clicked.connect(self.unselect_all)
 
+        self.hdf5_rb.toggled.connect(lambda checked: self.set_cadpts_fplain_enabled(not checked)) # Enable cadpts and fplain only when HDF5 export is not selected.
+
         self.setFixedSize(self.size())
 
         self.populate_components_dialog()
+
+    def set_cadpts_fplain_enabled(self, enabled):
+        """Enable or disable the cadpts and fplain checkbox, unchecking it when disabled."""
+        if not enabled:
+            self.cadpts_fplain_chbox.setChecked(False)
+        self.cadpts_fplain_chbox.setEnabled(enabled)
 
     def populate_components_dialog(self):
         s = QSettings()

--- a/flo2d/gui/dlg_components.py
+++ b/flo2d/gui/dlg_components.py
@@ -374,6 +374,10 @@ class ComponentsDialog(qtBaseClass, uiDialog):
                 self.mannings_n_and_Topo_chbox.setChecked(True)
                 self.mannings_n_and_Topo_chbox.setEnabled(True)
 
+            if not self.gutils.is_table_empty("grid"):
+                self.cadpts_fplain_chbox.setChecked(True)
+                self.cadpts_fplain_chbox.setEnabled(True)
+
             if not self.gutils.is_table_empty("tailing_cells"):
                 self.tailings_chbox.setChecked(True)
                 self.tailings_chbox.setEnabled(True)
@@ -487,6 +491,9 @@ class ComponentsDialog(qtBaseClass, uiDialog):
         if self.mannings_n_and_Topo_chbox.isChecked():
             self.components.append("Manning's n and Topo")
 
+        if self.cadpts_fplain_chbox.isChecked():
+            self.components.append("Cadpts and Fplain")
+
         if self.tailings_chbox.isChecked():
             self.components.append("Tailings")
 
@@ -543,3 +550,5 @@ class ComponentsDialog(qtBaseClass, uiDialog):
             self.spatial_lid_volume_chbox.setChecked(select)
         if self.mannings_n_and_Topo_chbox.isEnabled():
             self.mannings_n_and_Topo_chbox.setChecked(select)
+        if self.cadpts_fplain_chbox.isEnabled():
+            self.cadpts_fplain_chbox.setChecked(select)

--- a/flo2d/gui/grid_tools_widget.py
+++ b/flo2d/gui/grid_tools_widget.py
@@ -20,7 +20,7 @@ import numpy as np
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QDesktopServices, QColor
 from qgis.PyQt.QtWidgets import QProgressDialog
-from qgis._core import QgsFeatureRequest, QgsProject, QgsMeshLayer, QgsMeshDatasetIndex
+from qgis._core import QgsFeatureRequest, QgsProject, QgsMeshLayer, QgsMeshDatasetIndex, QgsPointXY
 from qgis.core import NULL, Qgis, QgsFeature, QgsGeometry, QgsMessageLog, QgsWkbTypes
 from qgis.PyQt.QtCore import QSettings, Qt, QThread
 from qgis.PyQt.QtWidgets import (
@@ -1178,21 +1178,48 @@ class GridToolsWidget(qtBaseClass, uiDialog):
                     geom = geom.buffer(0.0, 5)
                     if not geom.isGeosValid():
                         continue
+                # Convert every source geometry to 2D Polygon geometry.
                 if geom.isMultipart():
-                    new_geoms = [QgsGeometry.fromPolygonXY(g) for g in geom.asMultiPolygon()]
+                    new_geoms = []
+                    for polygon in geom.asMultiPolygon():
+                        rings = []
+                        for ring in polygon:
+                            rings.append([QgsPointXY(point.x(), point.y()) for point in ring])
+                        new_geoms .append(QgsGeometry.fromPolygonXY(rings))
                 else:
-                    new_geoms = [geom]
+                    polygon = geom.asPolygon()
+                    rings=[]
+                    for ring in polygon:
+                        rings.append([QgsPointXY(point.x(), point.y()) for point in ring])
+                    new_geoms = [QgsGeometry.fromPolygonXY(rings)]
+
+                # Add each converted polygon to user_layer
                 for new_geom in new_geoms:
                     user_feat = QgsFeature(blocked_areas_fields)
                     user_feat.setGeometry(new_geom)
+
                     for user_field_name, external_field_name in field_names_map.items():
                         external_value = feat[external_field_name]
-                        user_feat[user_field_name] = int(external_value) if external_value != NULL else external_value
+                        user_feat[user_field_name] = (int(external_value) if external_value != NULL else external_value)
                     user_feats.append(user_feat)
             blocked_areas_lyr.startEditing()
             blocked_areas_lyr.deleteFeatures([f.id() for f in blocked_areas_lyr.getFeatures()])
-            blocked_areas_lyr.addFeatures(user_feats)
-            blocked_areas_lyr.commitChanges()
+
+            # Add all converted external features to the blocked areas layer and roll back if the insertion fails
+            add_result = blocked_areas_lyr.addFeatures(user_feats)
+            if not add_result:
+                if blocked_areas_lyr.isEditable():
+                    blocked_areas_lyr.rollBack()
+                raise RuntimeError("Could not add features to Blocked areas.")
+
+            # Commit the imported features to the geopackage and roll back the edit session if commit fails
+            commit_result = blocked_areas_lyr.commitChanges()
+            if not commit_result:
+                errors = blocked_areas_lyr.commitErrors()
+                if blocked_areas_lyr.isEditable():
+                    blocked_areas_lyr.rollBack()
+                raise RuntimeError("Could not commit Blocked areas:\n" + "\n".join(errors))
+
             blocked_areas_lyr.updateExtents()
             blocked_areas_lyr.triggerRepaint()
             QApplication.restoreOverrideCursor()

--- a/flo2d/ui/components.ui
+++ b/flo2d/ui/components.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>671</width>
-    <height>352</height>
+    <height>397</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -28,6 +28,38 @@
    </property>
    <item row="4" column="2">
     <layout class="QGridLayout" name="gridLayout_3">
+     <item row="8" column="0" rowspan="2">
+      <spacer name="verticalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="spatial_lid_volume_chbox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LID_VOLUME.DAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Spatial LID Volume</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="0">
       <widget class="QCheckBox" name="spatial_tolerance_chbox">
        <property name="enabled">
@@ -44,6 +76,50 @@
        </property>
        <property name="text">
         <string>Spatial Tolerance</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QCheckBox" name="mudflo_chbox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;CONT.DAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>MODFLO-2D</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="spatial_shallow_n_chbox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SHALLOWN_SPATIAL.DAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Spatial Shallow-n</string>
        </property>
        <property name="checked">
         <bool>false</bool>
@@ -94,69 +170,6 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="spatial_lid_volume_chbox">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;LID_VOLUME.DAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Spatial LID Volume</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="spatial_shallow_n_chbox">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SHALLOWN_SPATIAL.DAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Spatial Shallow-n</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QCheckBox" name="mudflo_chbox">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;CONT.DAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>MODFLO-2D</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
      <item row="6" column="0">
       <widget class="QCheckBox" name="mannings_n_and_Topo_chbox">
        <property name="enabled">
@@ -179,18 +192,24 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="0" rowspan="2">
-      <spacer name="verticalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
+     <item row="7" column="0">
+      <widget class="QCheckBox" name="cadpts_fplain_chbox">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-      </spacer>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;CADPTS.DAT&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;FPLAIN.DAT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Cadpts and Fplain</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
- Add Cadpts and Fplain checkbox to components dialog.
- Ensure CADPTS.DAT and FPLAIN.DAT can be exported during normal components export process.
- Ensure cadpts and fplain checkbox in components dialog is unchecked and disabled when doing an hdf5 export, or when hdf5 radio button is selected during a quick run.